### PR TITLE
Exclude locked bundles from analysis

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -77,6 +77,14 @@ process find_new_updated {
             exit 0
         fi
 
+        # Check for the existence of Atlas prod lock files indicating loading in progress
+
+        bundleLocks=\$(ls \$SCXA_RESULTS/\$expName/*/bundle/atlas_prod.loading 2>/dev/null || true)
+        if [ -n "\$bundleLocks\" ]; then
+            echo "One or more sub-experiments are locked for loading" 1>&2
+            exit 0
+        fi 
+
         # Start by assuming a new experiment
         
         newExperiment=1


### PR DESCRIPTION
This PR implements a mechanism suggested by @pcm32 so that individual bundle directories can be excluded from possible re-analysis while they're being processed by the prod pipelines.

Note that this allows for the possibility of sub-experiments (though we're not doing this yet), so any sub-experiment with a locked bundle will prevent the experiment as whole from being re-analysed.