### PR TITLE
Feature/limit reruns on sdrf edit

### DIFF
--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -854,7 +854,7 @@ configs <- lapply(species_list, function(species){
       paste0("    protocol = '", protocol, "'")
     )
 
-    config_fields <- c(run = run.col, layout = library.layout.col, fastq = paste(fastq.fields, collapse=',')
+    config_fields <- c(run = run.col, layout = library.layout.col, fastq = paste(fastq.fields, collapse=','))
 
     # Record if we have an HCA experiment
 
@@ -987,8 +987,9 @@ configs <- lapply(species_list, function(species){
     # Create the config fields section
 
     config <- c(
+      config,
       paste0("\n    fields {"),
-      unlist(lapply(names(config_fields), function(x) paste0("        ", x," = '", config_fields[x], "'")))
+      unlist(lapply(names(config_fields), function(x) paste0("        ", x," = '", config_fields[x], "'"))),
       '    }\n'
     )
 
@@ -1110,6 +1111,7 @@ for (species in names(configs)){
 
     out.dir <- file.path(opt$out_conf, species)
     dir.create(out.dir, showWarnings = FALSE)
+    dir.create(opt$out_conf, showWarnings = FALSE)
  
     # If there is metadata then point to it from the config file
   

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -1109,8 +1109,6 @@ for (species in names(configs)){
     config <- configs[[species]][[protocol]]$config
     metadata <- configs[[species]][[protocol]]$metadata
 
-    out.dir <- file.path(opt$out_conf, species)
-    dir.create(out.dir, showWarnings = FALSE)
     dir.create(opt$out_conf, showWarnings = FALSE)
  
     # If there is metadata then point to it from the config file

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -28,7 +28,7 @@ option_list <- list(
   make_option(c("-c","--check_only"),action="store_true",dest="check_only",default=FALSE,help="Checks the sdrf/idf but skips the generation of the configuration file."),
   make_option(c("-v","--verbose"),action="store_true",dest="verbose",default=FALSE,help="Produce verbose output."),
   make_option(c("--debug"),action="store_true",dest="debug",default=FALSE,help="Debug mode"),
-  make_option(c("-o", "--out_conf"), type="character",default=NULL,help="Filename of the new iRAP's configuration file.")
+  make_option(c("-o", "--out_conf"), type="character",default=NULL,help="Output directory for configuration files.")
 )
 
 multiple.options = list()
@@ -846,30 +846,27 @@ configs <- lapply(species_list, function(species){
     rownames(species.protocol.layout) <- species.protocol.layout[[run.col]]
   
     # Generate starting config file content
- 
+
     config <- c(
       "\nparams{",
       paste0("    name = '", opt$name, "'"),
       paste0("    organism = '", species, "'"),
-      paste0("    protocol = '", protocol, "'"),
-      paste0("\n    fields {"),
-      paste0("        run = '", run.col, "'"),
-      paste0("        layout = '", library.layout.col, "'"),
-      paste0("        fastq = '", paste(fastq.fields, collapse=','), "'")
+      paste0("    protocol = '", protocol, "'")
     )
+
+    config_fields <- c(run = run.col, layout = library.layout.col, fastq = paste(fastq.fields, collapse=',')
 
     # Record if we have an HCA experiment
 
     if( ! is.null(hca.bundle.uuid.col) ){
       protocol$is.hca <- TRUE
-      config <- c(config, paste0("        hca_uuid = '", hca.bundle.uuid.col, "'"))
-      config <- c(config, paste0("        hca_version = '", hca.bundle.uuid.col, "'"))
+      config_fields <- c(config_fields, c(hca_uuid = hca.bundle.uuid.col, hca_version = hca.bundle.uuid.col))    
     }   
     
     ## Field to use for quality filtering
 
     if ( ! is.null(sc.quality.col)){
-      config <- c(config, paste0("        quality = '", sc.quality.col, "'"))
+      config_fields['quality'] <- sc.quality.col 
     }
 
     ## Anything other than ERCC will be ignored
@@ -879,7 +876,7 @@ configs <- lapply(species_list, function(species){
     if (properties$has.spikes){
       spikein <- tolower(unique(species.protocol.sdrf[[spike.in.col]]))
       if ( grepl("ercc.*",spikein) ) {
-        config <- c( config, paste0("        spike = '", paste(spike.in.col, collapse=','), "'") )
+        config_fields['spike'] <- paste(spike.in.col, collapse=',')
         spikes <- paste0("    spikes = 'ercc'"  )
       }else{
         print(paste("ignoring", spikein, 'for spikein'))
@@ -889,13 +886,13 @@ configs <- lapply(species_list, function(species){
     ## Set up for technical replication (or not)
   
     if(properties$has.techrep) {
-      config <- c( config, paste0("        techrep = '", paste(techrep.col, collapse=','), "'") )
+      config_fields['techrep'] <- paste(techrep.col, collapse=',')
     }
 
     # Do any rows need stranded analysis
 
     if (properties$has.strandedness){
-      config <- c( config, paste0("        strand = '", paste(strand.col, collapse=','), "'") )
+      config_fields['strand'] <- paste(strand.col, collapse=',')
     }
     
     # For droplet techs, add colums with strighforward statements of the URIs
@@ -949,7 +946,7 @@ configs <- lapply(species_list, function(species){
           }
           species.protocol.sdrf[[uri_field]] <- unlist(lapply(1:nrow(species.protocol.sdrf), function(x) species.protocol.sdrf[x, uri_fields[x]]))      
           
-          config <- c(config, paste0("        ", uri_field, " = '", uri_field, "'"))
+          config_fields[uri_field] <- uri_field
       }
 
       # Record the barcode position and offset fields
@@ -966,14 +963,14 @@ configs <- lapply(species_list, function(species){
               # We can populate a field with the default value for the protocol if necessary
 
               species.protocol.sdrf[[field_label]] <- droplet.protocol.defaults[[protocol]][[field_label]]
-              config <- c(config, paste0("        ", field_label, " = '", field_label, "'"))
+              config_fields[field_label] <- field_label
           }else{
             perror(paste(field_label, 'field not present, and default not known for protocol', protocol))
             q(status=1)
           }
 
         }else{
-          config <- c(config, paste0("        ", field_label, " = '", field_name, "'"))
+          config_fields[field_label] <- field_name
         }
       }
 
@@ -985,15 +982,19 @@ configs <- lapply(species_list, function(species){
       cell.count.col <- 'cell count'
       species.protocol.sdrf[[cell.count.col]] <- NA
     }
-    config <- c( config, paste0("        cell_count = '", cell.count.col, "'") )
+    config_fields['cell_count'] <- cell.count.col
+
+    # Create the config fields section
+
+    config <- c(
+      paste0("\n    fields {"),
+      unlist(lapply(names(config_fields), function(x) paste0("        ", x," = '", config_fields[x], "'")))
+      '    }\n'
+    )
 
     # Re-save the tweaked SDRF for output
-    sdrf.by.species.protocol[[species]][[protocol]] <<- species.protocol.sdrf        
+    sdrf.by.species.protocol[[species]][[protocol]] <<- species.protocol.sdrf[, config_fields]        
  
-    # Close out that config section
-
-    config <- c(config, '    }\n')
-
     # Put spikes in if present
 
     config <- c (config, spikes)

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -1028,7 +1028,7 @@ configs <- lapply(species_list, function(species){
       )
     }
   
-    config <- c(paste("// Generated", date(), "from", opt$sdrf), config, paste0("\n    extra_metadata = '", paste0(opt$name, ".metadata.tsv'")), "}\n")
+    config <- c(paste("// Generated from", opt$sdrf), config, paste0("\n    extra_metadata = '", paste0(opt$name, ".metadata.tsv'")), "}\n")
 
     # Generate metadata file content to save
   

--- a/main.nf
+++ b/main.nf
@@ -190,6 +190,10 @@ process generate_config {
         done
     else
         echo "Config files have not changed, no need to re-run"
+
+        # Update the manifest time stamps to prevent re-config next time
+
+        touch -m \$SCXA_RESULTS/\$expName/*/bundle/MANIFEST
     fi
     rm -rf try_conf 
     """

--- a/main.nf
+++ b/main.nf
@@ -153,14 +153,17 @@ process generate_config {
     # Check for existing copies the config and derived SDRF. If neither have
     # changed, no need to re-analyse- even if the SDRF has been edited.
 
-    for ext in .sdrf.txt .conf; do
+    for ext in sdrf.txt conf; do
         while read -r tc; do
             if [ -e \$SCXA_CONF/study/\$(basename \$tc) ]; then
+                set +e
                 diff \$tc \$SCXA_CONF/study/\$(basename \$tc) > /dev/null 2>&1
-                
+
                 if [ \$? -ne 1 ]; then
                     newExperiment=1
                 fi
+
+                set -e
             fi
         done <<< "\$(ls try_conf/*.\$ext)"
     done
@@ -171,7 +174,6 @@ process generate_config {
    if [ \$newExperiment -eq 1 ]; then
 
         mv try_conf/* .
-        rm -rf try_conf 
 
         # Only remove downstream results where we're not re-using them
         reset_stages='bundle'
@@ -186,8 +188,10 @@ process generate_config {
         for stage in \$reset_stages; do
             rm -rf $SCXA_RESULTS/$expName/*/\$stage
         done
-
+    else
+        echo "Config files have not changed, no need to re-run"
     fi
+    rm -rf try_conf 
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -158,7 +158,7 @@ process generate_config {
             if [ -e \$SCXA_CONF/study/\$(basename \$tc) ]; then
                 diff \$tc \$SCXA_CONF/study/\$(basename \$tc) > /dev/null 2>&1
                 
-                if [ $? -ne 1 ]; then
+                if [ \$? -ne 1 ]; then
                     newExperiment=1
                 fi
             fi

--- a/main.nf
+++ b/main.nf
@@ -159,7 +159,7 @@ process generate_config {
                 set +e
                 diff \$tc \$SCXA_CONF/study/\$(basename \$tc) > /dev/null 2>&1
 
-                if [ \$? -ne 1 ]; then
+                if [ \$? -ne 0 ]; then
                     newExperiment=1
                 fi
 

--- a/main.nf
+++ b/main.nf
@@ -162,7 +162,7 @@ process generate_config {
                     newExperiment=1
                 fi
             fi
-        done <<< "\$(ls try_conf/*.\$ext)
+        done <<< "\$(ls try_conf/*.\$ext)"
     done
 
     # If either of the files has changes for any of the species in the

--- a/main.nf
+++ b/main.nf
@@ -193,7 +193,7 @@ process generate_config {
 
         # Update the manifest time stamps to prevent re-config next time
 
-        touch -m \$SCXA_RESULTS/\$expName/*/bundle/MANIFEST
+        touch -m $SCXA_RESULTS/$expName/*/bundle/MANIFEST
     fi
     rm -rf try_conf 
     """


### PR DESCRIPTION
This PR makes changes to the single cell control workflow, such that re-runs are not necessarily triggered by updates to SDRF files. Still doing some final tests, but I'm fairly sure this will work.

The pipeline uses a subsetted SDRF file with columns added during configuration and split by species (though multi-species analysis is not allowed as yet). Previously this contained all columns, now it will contain only those columns pertinent for analysis. This means that the SDRF used for analysis will not change unless those specific fields are changed. 

The PR therefore changes the config R script to output the newly reduced SDRF files, and the pipeline to check the output of the config check for differences. 

This will only work for future runs. For the present situation we will need to run the config script in isolation over the existing SDRF files to ensure the reduced configs are in place for comparisons on future runs and prevent unnecessary re-analysis.