### PR TITLE
Feature/use isl refs

### DIFF
--- a/bin/parseIslConfig.sh
+++ b/bin/parseIslConfig.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
-species=$1
+conf_file=$1
 field=$2
 
-filename=$(grep $field "$ISL_CONFIG_DIR/$species.conf" | awk -F'=' '{print $2}')
+if [ ! -e "$conf_file" ]; then
+    echo "Supplied iRAP conf file $conf_file does not exist" 1>&2
+    exit 1
+fi
+
+filename=$(grep $field "$conf_file" | awk -F'=' '{print $2}')
 if [ "$filename" == '' ];then
     echo -n 'None'
 else

--- a/bin/parseIslConfig.sh
+++ b/bin/parseIslConfig.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+species=$1
+field=$2
+
+filename=$(grep $field "$ISL_CONFIG_DIR/$species.conf" | awk -F'=' '{print $2}')
+if [ "$filename" == '' ];then
+    echo -n 'None'
+else
+    echo -n "$filename"
+fi

--- a/conf/reference/danio_rerio.conf
+++ b/conf/reference/danio_rerio.conf
@@ -1,0 +1,7 @@
+params {
+    reference {
+        gtf = 'danio_rerio/Danio_rerio.GRCz11.95.gtf.gz'
+        cdna = 'danio_rerio/Danio_rerio.GRCz11.cdna.all.95.fa.gz'
+        contamination_index = 'ecoli_fungi_viral'
+    }
+}

--- a/conf/reference/danio_rerio.conf
+++ b/conf/reference/danio_rerio.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        gtf = 'danio_rerio/Danio_rerio.GRCz11.95.gtf.gz'
-        cdna = 'danio_rerio/Danio_rerio.GRCz11.cdna.all.95.fa.gz'
-        contamination_index = 'ecoli_fungi_viral'
-    }
-}

--- a/main.nf
+++ b/main.nf
@@ -959,8 +959,16 @@ process bundle {
 
         # Retrieve the original reference file names to report to bundle 
         species_conf=$SCXA_PRE_CONF/reference/${species}.conf
-        cdna_fasta=$SCXA_DATA/reference/\$(parseNfConfig.py --paramFile \$species_conf --paramKeys params,reference,cdna)
-        cdna_gtf=$SCXA_DATA/reference/\$(parseNfConfig.py --paramFile \$species_conf --paramKeys params,reference,gtf)
+        
+        if [ -e "\$species_conf" ]; then
+            cdna_fasta=$SCXA_DATA/reference/\$(parseNfConfig.py --paramFile \$species_conf --paramKeys params,reference,cdna)
+            cdna_gtf=$SCXA_DATA/reference/\$(parseNfConfig.py --paramFile \$species_conf --paramKeys params,reference,gtf)
+        
+        elif [ "\$IRAP_CONFIG_DIR" != '' ] && [ "\$IRAP_DATA" != '' ]; then
+            irap_species_conf=$IRAP_CONFIG_DIR/${species}.conf
+            cdna_fasta=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf cdna_file)   
+            cdna_gtf=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf gtf_file)   
+        fi
 
         TPM_OPTIONS=''
         tpm_filesize=\$(stat --printf="%s" \$(readlink ${tpmMatrix}))

--- a/main.nf
+++ b/main.nf
@@ -336,7 +336,7 @@ process add_reference {
     # Use references from an IRAP config
 
     species_conf=$SCXA_PRE_CONF/reference/${species}.conf
-    if [ -e "\$species_conf ]; then
+    if [ -e "\$species_conf" ]; then
 
         cdna_fasta=$SCXA_DATA/reference/\$(parseNfConfig.py --paramFile \$species_conf --paramKeys params,reference,cdna)
         cdna_gtf=$SCXA_DATA/reference/\$(parseNfConfig.py --paramFile \$species_conf --paramKeys params,reference,gtf)
@@ -349,9 +349,10 @@ process add_reference {
 
     elif [ "\$IRAP_CONFIG_DIR" != '' ] && [ "\$IRAP_DATA" != '' ]; then
 
-        cdna_fasta=$IRAP_DATA/reference/\$(parseIslConfig.sh ${species} cdna_file)   
-        cdna_gtf=$IRAP_DATA/reference/\$(parseIslConfig.sh ${species} gtf_file)   
-        contamination_index=\$(parseIslConfig.sh ${species} cont_index)  
+        irap_species_conf=$ISL_CONFIG_DIR/$species.conf
+        cdna_fasta=$IRAP_DATA/reference/\$(parseIslConfig.sh \$irap_species_conf cdna_file)   
+        cdna_gtf=$IRAP_DATA/reference/\$(parseIslConfig.sh \$irap_species_conf gtf_file)   
+        contamination_index=\$(parseIslConfig.sh \$irap_species_conf cont_index)  
         
     fi
    

--- a/main.nf
+++ b/main.nf
@@ -349,7 +349,7 @@ process add_reference {
 
     elif [ "\$IRAP_CONFIG_DIR" != '' ] && [ "\$IRAP_DATA" != '' ]; then
 
-        irap_species_conf=$IRAP_CONFIG_DIR/$species.conf
+        irap_species_conf=$IRAP_CONFIG_DIR/${species}.conf
         cdna_fasta=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf cdna_file)   
         cdna_gtf=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf gtf_file)   
         contamination_index=\$(parseIslConfig.sh \$irap_species_conf cont_index)  

--- a/main.nf
+++ b/main.nf
@@ -677,6 +677,7 @@ if (skipAggregation == 'yes' ){
             # If we have a species-wise config, supply to aggregation
 
             species_conf=$SCXA_PRE_CONF/reference/${species}.conf
+            opt_conf=
             if  [ -e \$species_conf ]; then
                 opt_conf=" --config \$species_conf"
             fi            

--- a/main.nf
+++ b/main.nf
@@ -349,9 +349,9 @@ process add_reference {
 
     elif [ "\$IRAP_CONFIG_DIR" != '' ] && [ "\$IRAP_DATA" != '' ]; then
 
-        irap_species_conf=$ISL_CONFIG_DIR/$species.conf
-        cdna_fasta=$IRAP_DATA/reference/\$(parseIslConfig.sh \$irap_species_conf cdna_file)   
-        cdna_gtf=$IRAP_DATA/reference/\$(parseIslConfig.sh \$irap_species_conf gtf_file)   
+        irap_species_conf=$IRAP_CONFIG_DIR/$species.conf
+        cdna_fasta=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf cdna_file)   
+        cdna_gtf=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf gtf_file)   
         contamination_index=\$(parseIslConfig.sh \$irap_species_conf cont_index)  
         
     fi


### PR DESCRIPTION
This is a fix which does the first step of moving SC pipeline reference usage towards that of the bulk pipelines. The species references currently configured local to the SC pipelines will continue to be used for consistency. But there is now a 'fallback' which pulls reference data from the bulk pipelines. 

The idea is that species new to SC but not to bulk will no longer have to be added to SC configs. We can deprecate the SC-specific references as we re-run those studies, until all reference data is taken from the central location (at which point I'll remove the species-specific configs). 