### PR TITLE
Feature/git sdrfs

### DIFF
--- a/bin/submitControlWorkflow.sh
+++ b/bin/submitControlWorkflow.sh
@@ -72,6 +72,16 @@ popd > /dev/null
 
 export PATH=$(pwd)/workflow/scxa-workflows/bin:$PATH
 
+# Fetch the Git SDRFs
+
+if [ ! -d 'metadata' ]; then
+    git clone git@gitlab.ebi.ac.uk:ebi-gene-expression/scxa-metadata.git metadata
+fi
+
+pushd metadata
+git pull > /dev/null
+popd
+
 # Build the Nextflow command
 
 expNamePart=

--- a/bin/submitControlWorkflow.sh
+++ b/bin/submitControlWorkflow.sh
@@ -78,9 +78,9 @@ if [ ! -d 'metadata' ]; then
     git clone git@gitlab.ebi.ac.uk:ebi-gene-expression/scxa-metadata.git metadata
 fi
 
-pushd metadata
+pushd metadata > /dev/null
 git pull > /dev/null
-popd
+popd > /dev/null
 
 # Build the Nextflow command
 

--- a/bin/submitControlWorkflow.sh
+++ b/bin/submitControlWorkflow.sh
@@ -144,7 +144,7 @@ if [ -n "$tertiaryWorkflow" ]; then
     fi
 fi
 
-nextflowCommand="nextflow run -N $SCXA_REPORT_EMAIL -resume workflow/${workflow}/main.nf $expNamePart $skipQuantificationPart $skipAggregationPart $tertiaryWorkflowPart $skipTertiaryPart $galaxyCredentialsPart $overwritePart --enaSshUser fg_atlas_sc --sdrfDir $SCXA_SDRF_DIR -work-dir $workingDir"
+nextflowCommand="nextflow run -N $SCXA_REPORT_EMAIL -resume workflow/${workflow}/main.nf $expNamePart $skipQuantificationPart $skipAggregationPart $tertiaryWorkflowPart $skipTertiaryPart $galaxyCredentialsPart $overwritePart --enaSshUser fg_atlas_sc -work-dir $workingDir"
 
 # Run the LSF submission if it's not already running
 

--- a/main.nf
+++ b/main.nf
@@ -119,7 +119,7 @@ process find_new_updated {
         bundleLocks=\$(ls \$SCXA_RESULTS/$expName/*/bundle/atlas_prod.loading 2>/dev/null || true)
       
         if [ \$newExperiment -eq 1 ] && [ -z "\$bundleLocks" ]; then
-            cp \$(dirname \$(readlink $sdrfFile))/\${expName}.idf.txt .
+            cp \$(dirname \$(readlink $sdrfFile))/${expName}.idf.txt .
         fi
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -1,6 +1,5 @@
 #!/usr/bin/env nextflow
 
-sdrfDir = params.sdrfDir
 tertiaryWorkflow = params.tertiaryWorkflow
 overwrite = params.overwrite
 
@@ -34,7 +33,6 @@ if ( params.containsKey('skipTertiary') && params.skipTertiary == 'yes'){
 
 // Now we pick the SDRFs to use
 
-MANUAL_SDRFS = Channel.fromPath("${sdrfDir}/*.sdrf.txt", checkIfExists: true).map{ f -> tuple("${f.simpleName}", f) }
 GIT_SDRFS = Channel.fromPath("$SCXA_WORKFLOW_ROOT/metadata/**/*.sdrf.txt", checkIfExists: true).map{ f -> tuple("${f.simpleName}", f) }
 
 // If user has supplied an experiment ID, then filter SDRFs to just that
@@ -52,7 +50,6 @@ if ( params.containsKey('expName')){
 // SDRFs
 
 SDRF = GIT_SDRFS
-    .join(MANUAL_SDRFS, remainder: true)
     .filter( ~/.*\/.*${sdrfFilter}\..*/ )
     .map{ r -> tuple(r[0], r[1]) }
 

--- a/main.nf
+++ b/main.nf
@@ -173,7 +173,7 @@ process generate_config {
             while read -r tc; do
                 if [ -e \$SCXA_CONF/study/\$(basename \$tc) ]; then
                     set +e
-                    diff \$tc \$SCXA_CONF/study/\$(basename \$tc) > /dev/null 2>&1
+                    diff -I '^//' \$tc \$SCXA_CONF/study/\$(basename \$tc) > /dev/null 2>&1
 
                     if [ \$? -ne 0 ]; then
                         echo \$tc is different to \$SCXA_CONF/study/\$(basename \$tc)

--- a/main.nf
+++ b/main.nf
@@ -34,13 +34,6 @@ if ( params.containsKey('skipTertiary') && params.skipTertiary == 'yes'){
 
 // Now we pick the SDRFs to use
 
-if ( params.containsKey('expName')){
-    SDRF = Channel.fromPath("${sdrfDir}/${params.expName}.sdrf.txt", checkIfExists: true)
-    doneSuffix=".${params.expName}"    
-}else{
-    SDRF = Channel.fromPath("${sdrfDir}/*.sdrf.txt", checkIfExists: true)
-}
-
 MANUAL_SDRFS = Channel.fromPath("${sdrfDir}/*.sdrf.txt", checkIfExists: true).map{ f -> tuple("${f.simpleName}", f) }
 GIT_SDRFS = Channel.fromPath("$SCXA_WORKFLOW_ROOT/metadata/**/*.sdrf.txt", checkIfExists: true).map{ f -> tuple("${f.simpleName}", f) }
 


### PR DESCRIPTION
[edited based on below points]

This PR changes the control workflow for the single cell pipelines to use the annotation files placed in the Git repo at https://gitlab.ebi.ac.uk/ebi-gene-expression/scxa-metadata. The metadata repo is cloned (or just 'pulled') as part of the submission script to get most recent metadata edits. The workflow then uses files from this repository rather than those in the  SDRF directory (itself now a glorified checkout of the same repo, necessary for other dependent systems).

So this just removes an environmental dependency in order to pull the metadata files directly.