### PR TITLE
[WIP] Supply cell metadata to tertiary workflow

### DIFF
--- a/bin/deriveCellMetadata.sh
+++ b/bin/deriveCellMetadata.sh
@@ -13,13 +13,13 @@ if [ "$isDroplet" = 'False' ]; then
 
     cellMetaFile=$metaFile
 
-    cat $barcodesFile | while read -r l; do 
+     head -n 1 $sampleMetadataFile > cell_metadata.tsv.tmp && cat $barcodesFile | while read -r l; do 
         grep -P "^$l\t" $sampleMetadataFile
          if [ $? -ne 0 ]; then 
             echo "Missing metadata for $l" 1>&2
             exit 1
          fi 
-    done > cell_metadata.tsv
+    done > cell_metadata.tsv.tmp
 
 else
 
@@ -49,7 +49,7 @@ else
     cat $barcodesFile >> cells.tsv
 
     if [ "$(cat cells.tsv | wc -l)" = "$(cat sample_metadata.tsv | wc -l)" ]; then 
-        paste -d "\t" cells.tsv sample_metadata.tsv > cell_metadata.tsv.tmp
+        paste -d "\t" cells.tsv sample_metadata.tsv > cells_samples.tsv.tmp
     else
         echo "Number of cells not equal to number of lines in cell-expanded sample metadata" 1>&2
         exit 1
@@ -79,20 +79,18 @@ else
         done >> droplet_cell_metadata.tsv
 
         if [ "$(cat cell_metadata.tsv.tmp | wc -l)" = "$(cat droplet_cell_metadata.tsv | wc -l)" ]; then 
-            paste -d "\t" cell_metadata.tsv.tmp droplet_cell_metadata.tsv > cell_metadata.tsv    
+            paste -d "\t" cells_samples.tsv.tmp droplet_cell_metadata.tsv > cell_metadata.tsv.tmp  
+            rm droplet_cell_metadata.tsv
         else
             echo "Inconsistent number of lines derived from cell metadata" 1>&2
             exit 1
         fi
 
     else
+        cp cells_samples.tsv.tmp cell_metadata.tsv.tmp
         "No cells file present at $cells_file_name"
-        cp cell_metadata.tsv.tmp cell_metadata.tsv
     fi
+    rm cells_samples.tsv.tmp
 fi
-
-
-
-
-
-
+        
+mv cell_metadata.tsv.tmp cell_metadata.tsv

--- a/bin/deriveCellMetadata.sh
+++ b/bin/deriveCellMetadata.sh
@@ -19,7 +19,7 @@ if [ "$isDroplet" = 'False' ]; then
             echo "Missing metadata for $l" 1>&2
             exit 1
          fi 
-    done > cell_metadata.tsv.tmp
+    done >> cell_metadata.tsv.tmp
 
 else
 

--- a/bin/deriveCellMetadata.sh
+++ b/bin/deriveCellMetadata.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/sh
+
+expName=$1
+isDroplet=$2
+barcodesFile=$3
+sampleMetadataFile=${4}
+dropletMetadataFile=${5:-''}
+
+if [ "$isDroplet" = 'False' ]; then
+    
+    # For SMART experiments, grep out the metadata lines we need for each run.
+    # If matching metadata can't be found then there's something wrong
+
+    cellMetaFile=$metaFile
+
+    cat $barcodesFile | while read -r l; do 
+        grep -P "^$l\t" $sampleMetadataFile
+         if [ $? -ne 0 ]; then 
+            echo "Missing metadata for $l" 1>&2
+            exit 1
+         fi 
+    done > cell_metadata.tsv
+
+else
+
+    # For droplet experiments life is complicated. Cell IDs are of the form
+    # SAMPLE-BARCODE, so we split the sample ID out and use that to to
+    # duplicate sample info per row. Where a .cells.tsv file is available, this
+    # can be used to add cell-wise metadata.
+
+    # 1. Duplicate library-wise metadata across component cells, looking for
+    # the sample identifier of each cell ID in the first column of the sample
+    # metadata
+
+    echo "Copying library-wise metadata across cells..."
+
+    head -n 1 $sampleMetadataFile > sample_metadata.tsv && cat $barcodesFile | awk -F'-' '{print $1}' | while read -r l; do 
+        grep -P "^$l\t" $sampleMetadataFile
+         if [ $? -ne 0 ]; then 
+            echo "Missing metadata for \$l" 1>&2
+            exit 1
+         fi 
+    done >> sample_metadata.tsv
+
+    # 2. Derive a cell list that will be the first column of the final output,
+    # and paste in front of the sample metadata
+
+    echo "cell" > cells.tsv
+    cat $barcodesFile >> cells.tsv
+
+    if [ "$(cat cells.tsv | wc -l)" = "$(cat sample_metadata.tsv | wc -l)" ]; then 
+        paste -d "\t" cells.tsv sample_metadata.tsv > cell_metadata.tsv.tmp
+    else
+        echo "Number of cells not equal to number of lines in cell-expanded sample metadata" 1>&2
+        exit 1
+    fi
+
+    # 3. Now take cell-wise metadata found in the *.cells.tsv file (where
+    # present), find the matching lines for each cell identifier, and add the
+    # resulting columns to the output
+
+    type=$(echo $expName | awk -F'-' '{print $2}')
+    cells_file_name="$SCXA_WORKFLOW_ROOT/metadata/$type/${expName}/${expName}.cells.txt"
+    
+    if [ -e "$cells_file_name" ]; then
+
+        echo "Found cell metadata at $cells_file_name, adding to output metadata table..."
+    
+        # Barcodes without entries in the annotation, print the right number of
+        # delimiters such that we get empty fields
+
+        emptystring=$(head -n 1 $cells_file_name | sed s/[^\\t]//g)
+
+        head -n 1 $cells_file_name > droplet_cell_metadata.tsv && cat $barcodesFile | while read -r l; do 
+            grep -P "^$l\t" $cells_file_name
+            if [ $? -ne 0 ]; then  
+                echo -e "$emtpyString"
+            fi
+        done >> droplet_cell_metadata.tsv
+
+        if [ "$(cat cell_metadata.tsv.tmp | wc -l)" = "$(cat droplet_cell_metadata.tsv | wc -l)" ]; then 
+            paste -d "\t" cell_metadata.tsv.tmp droplet_cell_metadata.tsv > cell_metadata.tsv    
+        else
+            echo "Inconsistent number of lines derived from cell metadata" 1>&2
+            exit 1
+        fi
+
+    else
+        "No cells file present at $cells_file_name"
+        cp cell_metadata.tsv.tmp cell_metadata.tsv
+    fi
+fi
+
+
+
+
+
+

--- a/bin/deriveCellMetadata.sh
+++ b/bin/deriveCellMetadata.sh
@@ -45,11 +45,12 @@ else
     # 2. Derive a cell list that will be the first column of the final output,
     # and paste in front of the sample metadata
 
-    echo "cell" > cells.tsv
-    cat $barcodesFile >> cells.tsv
+    echo "cell" > cells.tsv.tmp
+    cat $barcodesFile >> cells.tsv.tmp
 
     if [ "$(cat cells.tsv | wc -l)" = "$(cat sample_metadata.tsv | wc -l)" ]; then 
-        paste -d "\t" cells.tsv sample_metadata.tsv > cells_samples.tsv.tmp
+        paste -d "\t" cells.tsv.tmp sample_metadata.tsv > cells_samples.tsv.tmp
+        rm -f cells.tsv.tmp
     else
         echo "Number of cells not equal to number of lines in cell-expanded sample metadata" 1>&2
         exit 1
@@ -71,16 +72,16 @@ else
 
         emptystring=$(head -n 1 $cells_file_name | sed s/[^\\t]//g)
 
-        head -n 1 $cells_file_name > droplet_cell_metadata.tsv && cat $barcodesFile | while read -r l; do 
+        head -n 1 $cells_file_name > droplet_cell_metadata.tsv.tmp && cat $barcodesFile | while read -r l; do 
             grep -P "^$l\t" $cells_file_name
             if [ $? -ne 0 ]; then  
                 echo -e "$emtpyString"
             fi
-        done >> droplet_cell_metadata.tsv
+        done >> droplet_cell_metadata.tsv.tmp
 
-        if [ "$(cat cell_metadata.tsv.tmp | wc -l)" = "$(cat droplet_cell_metadata.tsv | wc -l)" ]; then 
-            paste -d "\t" cells_samples.tsv.tmp droplet_cell_metadata.tsv > cell_metadata.tsv.tmp  
-            rm droplet_cell_metadata.tsv
+        if [ "$(cat cell_metadata.tsv.tmp | wc -l)" = "$(cat droplet_cell_metadata.tsv.tmp | wc -l)" ]; then 
+            paste -d "\t" cells_samples.tsv.tmp droplet_cell_metadata.tsv.tmp > cell_metadata.tsv.tmp  
+            rm droplet_cell_metadata.tsv.tmp
         else
             echo "Inconsistent number of lines derived from cell metadata" 1>&2
             exit 1

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -843,10 +843,15 @@ configs <- lapply(species_list, function(species){
     species.protocol.sdrf <- sdrf.by.species.protocol[[species]][[protocol]]
     properties <- species.protocol.properties[[species]][[protocol]]
   
-    # layout is the SDRF with the duplicated lanes for paired end removed
-    species.protocol.layout <- species.protocol.sdrf[!duplicated(species.protocol.sdrf[[run.col]]),,drop=FALSE]
-    rownames(species.protocol.layout) <- species.protocol.layout[[run.col]]
-  
+    # layout is the SDRF with the duplicated lanes for paired end (and possibly technical replication) removed
+    if(properties$has.techrep) {
+      species.protocol.layout <- species.protocol.sdrf[!duplicated(species.protocol.sdrf[[techrep.col]]),,drop=FALSE]
+      rownames(species.protocol.layout) <- species.protocol.layout[[techrep.col]]
+    }else{   
+      species.protocol.layout <- species.protocol.sdrf[!duplicated(species.protocol.sdrf[[run.col]]),,drop=FALSE]
+      rownames(species.protocol.layout) <- species.protocol.layout[[run.col]]
+    }
+
     # Generate starting config file content
 
     config <- c(

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -842,7 +842,7 @@ configs <- lapply(species_list, function(species){
  
     species.protocol.sdrf <- sdrf.by.species.protocol[[species]][[protocol]]
     properties <- species.protocol.properties[[species]][[protocol]]
-  
+ 
     # layout is the SDRF with the duplicated lanes for paired end (and possibly technical replication) removed
     if(properties$has.techrep) {
       species.protocol.layout <- species.protocol.sdrf[!duplicated(species.protocol.sdrf[[techrep.col]]),,drop=FALSE]
@@ -1068,9 +1068,9 @@ configs <- lapply(species_list, function(species){
     if (length(sdfcols2save2tsv) > 0){
       metadata <- species.protocol.layout[,sdfcols2save2tsv, drop = FALSE]
       metadata <- cbind(run=rownames(metadata),metadata)
-      colnames(metadata) <- metadata_cols
+      colnames(metadata) <- c('run', metadata_cols)
     }
-  
+
     list(config=config, metadata=metadata)
   })
 })

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -1056,16 +1056,14 @@ configs <- lapply(species_list, function(species){
     # Generate metadata file content to save
   
     metadata <- NULL
-    sdfcols2save2tsv <- getActualColnames(unique(c(
-      factors,
-      idf.factors,
-      idf.attrs,
-      techrep.col
-    )), species.protocol.sdrf)
+
+    metadata_cols <- unique(c(factors, idf.factors, idf.attrs, techrep.col))
+    sdfcols2save2tsv <- getActualColnames(metadata_cols, species.protocol.sdrf)
   
     if (length(sdfcols2save2tsv) > 0){
       metadata <- species.protocol.layout[,sdfcols2save2tsv, drop = FALSE]
       metadata <- cbind(run=rownames(metadata),metadata)
+      colnames(metadata) <- metadata_cols
     }
   
     list(config=config, metadata=metadata)

--- a/main.nf
+++ b/main.nf
@@ -746,7 +746,7 @@ if (skipAggregation == 'yes' ){
 
 CONF_WITH_ORIG_REFERENCE_FOR_TERTIARY
     .groupTuple( by: [0,1] )
-    .map{ row-> tuple( row[0], row[1], row[2].join(","), row[3][0], row[5][0], row[6][0]) }
+    .map{ row-> tuple( row[0], row[1], row[2].join(","), row[3][0], row[5][0], row[7][0]) }
     .unique()
     .join(COUNT_MATRICES, by: [0,1])
     .set { TERTIARY_INPUTS }         

--- a/main.nf
+++ b/main.nf
@@ -782,7 +782,7 @@ process add_cell_metadata {
 
         if [ "$isDroplet" = 'True' ]; then
             type=\$(echo $expName | awk -F'-' '{print \$2}')
-            cellsFileName="$SCXA_WORKFLOW_ROOT/metadata/$type/${expName}/${expName}.cells.txt"
+            cellsFileName="$SCXA_WORKFLOW_ROOT/metadata/\$type/${expName}/${expName}.cells.txt"
         fi
         
         # Derive a file of all the metadata we have for cells

--- a/main.nf
+++ b/main.nf
@@ -652,7 +652,7 @@ if (skipAggregation == 'yes' ){
         executor 'local'
         
         input:
-            set val(expName), val(species), file('quant_results/??/protocol'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*') from GROUPED_QUANTIFICATION_RESULTS   
+            set val(expName), val(species), file('quant_results/??/protocol'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*') from GROUPED_QUANTIFICATION_RESULTS   
 
         output:
             set val(expName), val(species), file("matrices/counts_mtx.zip") into COUNT_MATRICES
@@ -681,7 +681,7 @@ if (skipAggregation == 'yes' ){
         maxRetries 20
         
         input:
-            set val(expName), val(species), file('quant_results/??/protocol'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*') from GROUPED_QUANTIFICATION_RESULTS   
+            set val(expName), val(species), file('quant_results/??/protocol'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*'), file('quant_results/??/*') from GROUPED_QUANTIFICATION_RESULTS   
 
         output:
             set val(expName), val(species), file("matrices/counts_mtx.zip") into COUNT_MATRICES

--- a/main.nf
+++ b/main.nf
@@ -315,6 +315,7 @@ process markup_conf_files {
         mkdir -p out
         cp -p $confFile out/$confFile    
         cp -p $sdrfFile out/$sdrfFile    
+        cp -p $metaFile out/$metaFile    
         
         protocolConfig=${baseDir}/conf/protocol/\${protocol}.conf
         if [ ! -e \$protocolConfig ]; then

--- a/main.nf
+++ b/main.nf
@@ -278,7 +278,7 @@ process tag_meta{
         file(metaFile) from FLAT_METADATA_FILES
 
     output:
-        set stdout, file(metaFile) into TAGGED_CONF_FILES
+        set stdout, file(metaFile) into TAGGED_METADATA_FILES
 
     """
         echo -n $metaFile | sed 's/.metadata.tsv//'

--- a/main.nf
+++ b/main.nf
@@ -749,7 +749,48 @@ CONF_WITH_ORIG_REFERENCE_FOR_TERTIARY
     .map{ row-> tuple( row[0], row[1], row[2].join(","), row[3][0], row[5][0], row[7][0]) }
     .unique()
     .join(COUNT_MATRICES, by: [0,1])
-    .set { TERTIARY_INPUTS }         
+    .set { PRE_TERTIARY_INPUTS }         
+
+// Create a table with the available metadata for each cell in the expression
+// matrix
+
+process add_cell_metadata {
+
+    memory { 4.GB * task.attempt }
+    errorStrategy { task.exitStatus == 130 || task.exitStatus == 137 || task.attempt<=3  ? 'retry' : 'ignore' }
+    maxRetries 3
+    
+    input:
+        set val(expName), val(species), val(protocolList), file(confFile), file(metaFile), file(referenceGtf), file(countMatrix) from PRE_TERTIARY_INPUTS
+
+    output:
+        set val(expName), val(species), val(protocolList), file(confFile), file(metaFile), file(referenceGtf), file(countMatrix), file('cell_metadata.tsv') into TERTIARY_INPUTS
+        
+    script: 
+
+        def isDroplet='False'
+        protocol_list=protocolList.split(',').toList()
+        experiment_droplet_protocols=protocol_list.intersect(dropletProtocols)
+        if ( experiment_droplet_protocols.size() > 0){
+            isDroplet='True'
+        }
+    """
+        zipdir=\$(unzip -qql ${countMatrix.getBaseName()}.zip | head -n1 | tr -s ' ' | cut -d' ' -f5- | sed 's|/||')
+        unzip ${countMatrix.getBaseName()}        
+    
+        cellsFileName=
+
+        if [ "$isDroplet" = 'True' ]; then
+            type=\$(echo $expName | awk -F'-' '{print \$2}')
+            cellsFileName="$SCXA_WORKFLOW_ROOT/metadata/$type/${expName}/${expName}.cells.txt"
+        fi
+        
+        # Derive a file of all the metadata we have for cells
+
+        deriveCellMetadata.sh $expName $isDroplet \${zipdir}/barcodes.tsv $metaFile \$cellsFileName
+    """
+}
+
 
 if ( tertiaryWorkflow == 'scanpy-workflow'){
 
@@ -816,7 +857,7 @@ if ( tertiaryWorkflow == 'scanpy-workflow'){
         
             executor 'local'
             input:
-                set val(expName), val(species), val(protocolList), file(confFile), file(metaFile), file(referenceGtf), file(countMatrix) from TERTIARY_INPUTS
+                set val(expName), val(species), val(protocolList), file(confFile), file(metaFile), file(referenceGtf), file(countMatrix), file(cellMeta) from TERTIARY_INPUTS
             
             output:
                 set val(expName), val(species), val(protocolList), file(confFile), file("matrices/${countMatrix}"), file("matrices/raw_filtered.zip"), file("matrices/filtered_normalised.zip"), file("clusters_for_bundle.txt"), file("umap"), file("tsne"), file("markers"), file('clustering_software_versions.txt') into TERTIARY_RESULTS
@@ -851,7 +892,7 @@ if ( tertiaryWorkflow == 'scanpy-workflow'){
             maxRetries 3
               
             input:
-                set val(expName), val(species), val(protocolList), file(confFile), file(metaFile), file(referenceGtf), file(countMatrix) from TERTIARY_INPUTS
+                set val(expName), val(species), val(protocolList), file(confFile), file(metaFile), file(referenceGtf), file(countMatrix), file(cellMeta) from TERTIARY_INPUTS
 
             output:
                 set val(expName), val(species), val(protocolList), file(confFile), file("matrices/${countMatrix}"), file("matrices/raw_filtered.zip"), file("matrices/filtered_normalised.zip"), file("clusters_for_bundle.txt"), file("umap"), file("tsne"), file("markers"), file('clustering_software_versions.txt') into TERTIARY_RESULTS
@@ -883,18 +924,19 @@ if ( tertiaryWorkflow == 'scanpy-workflow'){
                 export matrix_file=\${zipdir}/matrix.mtx.gz
                 export genes_file=\${zipdir}/genes.tsv.gz
                 export barcodes_file=\${zipdir}/barcodes.tsv.gz
+                export cells_metadata_file=$cellMeta
                 export tpm_filtering='False'
 
                 export create_conda_env=no
                 export GALAXY_CRED_FILE=$galaxyCredentials
                 export GALAXY_INSTANCE=ebi_cluster_ge_user
-       
+      
                 if [ "$isDroplet" = 'True' ]; then
                     export FLAVOUR=w_droplet_clustering
                 else
                     export FLAVOUR=w_smart-seq_clustering
                 fi
-
+                
                 run_flavour_workflows.sh
 
                 if [ \$? -eq 0 ]; then


### PR DESCRIPTION
This PR adds the generation of a cell-wise metadata table to the control workflow, exporting it to the environment from which the Galaxy tertiary analysis pipeline is executed. Future deployments of that pipeline will be able to use this table, building it in the starting Scanpy object, from where it will be used for analysis and provision of a 'project Loom (or anndata)' file to users. 

Firstly, I've tidied up the way in which the config generation script (derived from one previously used by iRAP) makes a metadata table with factors etc. This must then be passed through the workflow until required by the Scanpy process. 

Secondly, I've added processes to match the metadata file to the cell-wise matrix.  For SMART experiments, this just entails extracting the relevant rows of the SDRF-derived metadata file to match the cell names. For Droplet it's more complex. We have to first 'expand' the metadata, duplicating it over the component cells of each library. Then we need to add in any curations that have been provided in a .cells.txt file.

For the file to actually be used requires use of an updated 10X parsing module, as used in the updated SC workflow to be deployed at https://github.com/ebi-gene-expression-group/scxa-workflows/pull/13.

This work may at some point be superseded by use of condensed SDRF.