### PR TITLE
Feature/newest reference

### DIFF
--- a/conf/reference/anopheles_gambiae.conf
+++ b/conf/reference/anopheles_gambiae.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        cdna = 'anopheles_gambiae/Anopheles_gambiae.AgamP4.cdna.all.42.fa.gz'
-        gtf = 'anopheles_gambiae/Anopheles_gambiae.AgamP4.42.gtf.gz'
-        contamination_index = 'ecoli_fungi_viral'
-    }
-}

--- a/conf/reference/arabidopsis_thaliana.conf
+++ b/conf/reference/arabidopsis_thaliana.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        gtf = 'arabidopsis_thaliana/Arabidopsis_thaliana.TAIR10.44.gtf.gz'
-        cdna = 'arabidopsis_thaliana/Arabidopsis_thaliana.TAIR10.cdna.all.44.fa.gz'
-        contamination_index = 'ecoli_fungi_viral'
-    }
-}

--- a/conf/reference/caenorhabditis_elegans.conf
+++ b/conf/reference/caenorhabditis_elegans.conf
@@ -1,8 +1,0 @@
-params {
-    reference {
-        gtf = 'caenorhabditis_elegans/Caenorhabditis_elegans.WBcel235.95.gtf.gz'
-        cdna = 'caenorhabditis_elegans/Caenorhabditis_elegans.WBcel235.cdna.all.95.fa.gz'
-        contamination_index = 'ecoli_fungi_viral'
-        ignoreTxVersion = 'FALSE'
-    }
-}

--- a/conf/reference/callithrix_jacchus.conf
+++ b/conf/reference/callithrix_jacchus.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        cdna = 'callithrix_jacchus/Callithrix_jacchus.ASM275486v1.cdna.all.fa.gz'
-        gtf = 'callithrix_jacchus/Callithrix_jacchus.ASM275486v1.96.gtf.gz'
-        contamination_index = 'ecoli_fungi_viral'
-    }
-}

--- a/conf/reference/danio_rerio.conf
+++ b/conf/reference/danio_rerio.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        gtf = 'danio_rerio/Danio_rerio.GRCz11.95.gtf.gz'
-        cdna = 'danio_rerio/Danio_rerio.GRCz11.cdna.all.95.fa.gz'
-        contamination_index = 'ecoli_fungi_viral'
-    }
-}

--- a/conf/reference/drosophila_melanogaster.conf
+++ b/conf/reference/drosophila_melanogaster.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        gtf = 'drosophila_melanogaster/Drosophila_melanogaster.BDGP6.95.gtf.gz'
-        cdna = 'drosophila_melanogaster/Drosophila_melanogaster.BDGP6.cdna.all.95.fa.gz'
-        contamination_index = 'ecoli_fungi_viral'
-    }
-}

--- a/conf/reference/gallus_gallus.conf
+++ b/conf/reference/gallus_gallus.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        cdna = 'gallus_gallus/Gallus_gallus.GRCg6a.cdna.all.98.fa.gz'
-        gtf = 'gallus_gallus/Gallus_gallus.GRCg6a.98.gtf.gz'
-        contamination_index = 'ecoli_fungi_viral'
-    }
-}

--- a/conf/reference/homo_sapiens.conf
+++ b/conf/reference/homo_sapiens.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        cdna = 'homo_sapiens/Homo_sapiens.GRCh38.cdna.all.95.fa.gz'
-        gtf = 'homo_sapiens/Homo_sapiens.GRCh38.95.gtf.gz'
-        contamination_index = 'ecoli_fungi_viral'
-    }
-}

--- a/conf/reference/macaca_mulatta.conf
+++ b/conf/reference/macaca_mulatta.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        cdna = 'macaca_mulatta/Macaca_mulatta.Mmul_8.0.1.cdna.all.95.fa.gz'
-        gtf = 'macaca_mulatta/Macaca_mulatta.Mmul_8.0.1.95.gtf.gz'
-        contamination_index = 'ecoli_fungi_viral'
-    }
-}

--- a/conf/reference/mus_musculus.conf
+++ b/conf/reference/mus_musculus.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        gtf = 'mus_musculus/Mus_musculus.GRCm38.95.gtf.gz'
-        cdna = 'mus_musculus/Mus_musculus.GRCm38.cdna.all.95.fa.gz'
-        contamination_index = 'ecoli_fungi_viral'
-    }
-}

--- a/conf/reference/plasmodium_berghei.conf
+++ b/conf/reference/plasmodium_berghei.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        gtf = 'plasmodium_berghei/Plasmodium_berghei.PBANKA01.42.gtf.gz'
-        cdna = 'plasmodium_berghei/Plasmodium_berghei.PBANKA01.cdna.all.42.fa.gz'
-        contamination_index = 'ecoli_fungi_viral'
-    }
-}

--- a/conf/reference/plasmodium_falciparum_3d7.conf
+++ b/conf/reference/plasmodium_falciparum_3d7.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        gtf = 'plasmodium_falciparum_3d7/Plasmodium_falciparum.EPr1.43.gtf.gz'
-        cdna = 'plasmodium_falciparum_3d7/Plasmodium_falciparum.EPr1.cdna.all.43.fa.gz'
-        contamination_index = 'ecoli_fungi_viral'
-    }
-}

--- a/conf/reference/rattus_norvegicus.conf
+++ b/conf/reference/rattus_norvegicus.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        gtf = 'rattus_norvegicus/Rattus_norvegicus.Rnor_6.0.95.gtf.gz'
-        cdna = 'rattus_norvegicus/Rattus_norvegicus.Rnor_6.0.cdna.all.95.fa.gz'
-        contamination_index = 'ecoli_fungi_viral'
-    }
-}

--- a/conf/reference/saccharomyces_cerevisiae.conf
+++ b/conf/reference/saccharomyces_cerevisiae.conf
@@ -1,7 +1,0 @@
-params {
-    reference {
-        gtf = 'saccharomyces_cerevisiae/Saccharomyces_cerevisiae.R64-1-1.95.gtf.gz'
-        cdna = 'saccharomyces_cerevisiae/Saccharomyces_cerevisiae.R64-1-1.cdna.all.95.fa.gz'
-        ignoreTxVersion = 'FALSE'
-    }
-}

--- a/conf/reference/schistosoma_mansoni.conf
+++ b/conf/reference/schistosoma_mansoni.conf
@@ -1,8 +1,0 @@
-params {
-    reference {
-        gtf = 'schistosoma_mansoni/Schistosoma_mansoni.ASM23792v2.42.gtf.gz'
-        cdna = 'schistosoma_mansoni/Schistosoma_mansoni.ASM23792v2.cdna.all.fa.gz'
-        contamination_index = 'ecoli_fungi_viral'
-        ignoreTxVersion = 'FALSE'
-    }
-}

--- a/main.nf
+++ b/main.nf
@@ -339,27 +339,35 @@ process add_reference {
         set val(expName), val(species), val(protocol), file(confFile), file(sdrfFile), file("*.fa.gz"), file("*.gtf.gz"), stdout into CONF_WITH_REFERENCE
 
     """
-    # Use references from an IRAP config
+    # Use references from the ISL setup
 
-    species_conf=$SCXA_PRE_CONF/reference/${species}.conf
-    if [ -e "\$species_conf" ]; then
-
-        cdna_fasta=$SCXA_DATA/reference/\$(parseNfConfig.py --paramFile \$species_conf --paramKeys params,reference,cdna)
-        cdna_gtf=$SCXA_DATA/reference/\$(parseNfConfig.py --paramFile \$species_conf --paramKeys params,reference,gtf)
-        contamination_index=\$(parseNfConfig.py --paramFile \$species_conf --paramKeys params,reference,contamination_index)
-        
-        if [ \$contamination_index != 'None' ]; then
-            contamination_index=$SCXA_DATA/contamination/\$contamination_index
-        fi
-    
-
-    elif [ "\$IRAP_CONFIG_DIR" != '' ] && [ "\$IRAP_DATA" != '' ]; then
+    if [ -n "\$ISL_GENOMES" ] && [ "\$IRAP_CONFIG_DIR" != '' ] && [ "\$IRAP_DATA" != '' ]; then
 
         irap_species_conf=$IRAP_CONFIG_DIR/${species}.conf
-        cdna_fasta=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf cdna_file)   
-        cdna_gtf=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf gtf_file)   
+
+        if [ ${params.islReferenceType} = 'newest' ]; then
+            gtf_pattern=\$(basename \$(cat \$ISL_GENOMES | grep $species | awk '{print $6}') | sed 's/RELNO/\\*/')
+            cdna_pattern=\$(basename \$(cat \$ISL_GENOMES | grep $species | awk '{print $5}') | sed 's/RELNO/\\*/')
+
+            cdna_gtf=\$(ls \$IRAP_DATA/reference/${species}/\$gtf_pattern | sort -r | head -n 1)
+            cdna_fasta=\$(ls \$IRAP_DATA/reference/${species}/\$cdna_pattern | sort -r | head -n 1)
+        else
+            cdna_fasta=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf cdna_file)   
+            cdna_gtf=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf gtf_file)   
+        fi
+
+        if [ ! -e "\$cdna_fasta" ]; then
+            echo "Fasta file \$cdna_fasta does not exist" 1>&2
+            exit 1
+        elif [ ! -e "\$cdna_gtf" ]; then
+            echo "GTF file \$cdna_gtf does not exist" 1>&2
+            exit 1
+        fi
+
         contamination_index=\$(parseIslConfig.sh \$irap_species_conf cont_index)  
-        
+    else
+        echo "All of environment variables ISL_GENOMES, IRAP_CONFIG_DIR AND IRAP_DATA must be set" 1>&2
+        exit 1
     fi
    
     echo -n "\$contamination_index"

--- a/main.nf
+++ b/main.nf
@@ -347,7 +347,7 @@ process add_reference {
 
         if [ ${params.islReferenceType} = 'newest' ]; then
             gtf_pattern=\$(basename \$(cat \$ISL_GENOMES | grep $species | awk '{print \$6}') | sed 's/RELNO/\\*/')
-            cdna_pattern=\$(basename \$(cat \$ISL_GENOMES | grep $species | awk '{print \$5}') | sed 's/RELNO/\\*/')
+            cdna_pattern=\$(basename \$(cat \$ISL_GENOMES | grep $species | awk '{print \$5}') | sed 's/.fa.gz/.\\*.fa.gz/') 
 
             cdna_gtf=\$(ls \$IRAP_DATA/reference/${species}/\$gtf_pattern | sort -r | head -n 1)
             cdna_fasta=\$(ls \$IRAP_DATA/reference/${species}/\$cdna_pattern | sort -r | head -n 1)

--- a/main.nf
+++ b/main.nf
@@ -346,8 +346,8 @@ process add_reference {
         irap_species_conf=$IRAP_CONFIG_DIR/${species}.conf
 
         if [ ${params.islReferenceType} = 'newest' ]; then
-            gtf_pattern=\$(basename \$(cat \$ISL_GENOMES | grep $species | awk '{print $6}') | sed 's/RELNO/\\*/')
-            cdna_pattern=\$(basename \$(cat \$ISL_GENOMES | grep $species | awk '{print $5}') | sed 's/RELNO/\\*/')
+            gtf_pattern=\$(basename \$(cat \$ISL_GENOMES | grep $species | awk '{print \$6}') | sed 's/RELNO/\\*/')
+            cdna_pattern=\$(basename \$(cat \$ISL_GENOMES | grep $species | awk '{print \$5}') | sed 's/RELNO/\\*/')
 
             cdna_gtf=\$(ls \$IRAP_DATA/reference/${species}/\$gtf_pattern | sort -r | head -n 1)
             cdna_fasta=\$(ls \$IRAP_DATA/reference/${species}/\$cdna_pattern | sort -r | head -n 1)

--- a/params.config
+++ b/params.config
@@ -7,4 +7,5 @@ params {
     tertiaryWorkflow = 'None'
     //teriaryWorkflow = 'scanpy-workflow'
 
+    islReferenceType = 'newest'
 }


### PR DESCRIPTION
So, I /think/ this is what is required for references for re-runs of the SC pipelines (see recent Slack query @pcm32 ). 

This PR pulls the most recent reference for an organism as dowloaded by ISL automated processes. This is **not** the version actually used by ISL in its config, which would be unnecessarily out of date for the single-cell pipelines. This also completely removes the use of references baked in to the pipeline config. 