### PR TITLE
Feature/controlled access

### DIFF
--- a/bin/checkForControlledAccess.sh
+++ b/bin/checkForControlledAccess.sh
@@ -20,7 +20,7 @@ if [ "$controlledAccessField" != 'None' ]; then
         echo "Specified controlled access datasets file $CONTROLLED_ACCESS_DATASETS does not exist" 1>&2
         exit 1
     else
-        datasetInfo=$(grep "^$expName\t" $CONTROLLED_ACCESS_DATASETS)
+        datasetInfo=$(grep "^$expName$(printf '\t')" $CONTROLLED_ACCESS_DATASETS)
         if [ $? -ne 0 ]; then
             echo "Can't find controlled access info for $expName in $CONTROLLED_ACCESS_DATASETS" 1>&2
             exit 1

--- a/bin/checkForControlledAccess.sh
+++ b/bin/checkForControlledAccess.sh
@@ -6,9 +6,13 @@ confFile=$2
 # Check if we're looking at a controlled access datasets, and if we have the
 # necessaries
 
-controlledAccessStatus=$(parseNfConfig.py --paramFile $confFile --paramKeys params,controlled_access)
+controlledAccessField=$(parseNfConfig.py --paramFile $confFile --paramKeys params,fields,controlled_access)
 
-if [ "$controlledAccessStatus" == 'yes' ]; then 
+# This controlled access field will only have been set by the config script if
+# a) a controlled access field is present in the SDRF and b) it has some 'yes'
+# values
+
+if [ "$controlledAccessField" != 'None' ]; then
     if [ -z "$CONTROLLED_ACCESS_DATASETS" ]; then
         echo "$expName is set as controlled access in $confFile, but the CONTROLLED_ACCESS_DATASETS environment variable is is not set" 1>&2
         exit 1

--- a/bin/checkForControlledAccess.sh
+++ b/bin/checkForControlledAccess.sh
@@ -16,6 +16,9 @@ if [ "$controlledAccessField" != 'None' ]; then
     if [ -z "$CONTROLLED_ACCESS_DATASETS" ]; then
         echo "$expName is set as controlled access in $confFile, but the CONTROLLED_ACCESS_DATASETS environment variable is is not set" 1>&2
         exit 1
+    elif [ ! -e "$CONTROLLED_ACCESS_DATASETS" ]; then
+        echo "Specified controlled access datasets file $CONTROLLED_ACCESS_DATASETS does not exist" 1>&2
+        exit 1
     else
         datasetInfo=$(grep "^$expName\t" $CONTROLLED_ACCESS_DATASETS)
         if [ $? -ne 0 ]; then

--- a/bin/checkForControlledAccess.sh
+++ b/bin/checkForControlledAccess.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+expName=$1
+confFile=$2
+
+# Check if we're looking at a controlled access datasets, and if we have the
+# necessaries
+
+controlledAccessStatus=$(parseNfConfig.py --paramFile $confFile --paramKeys params,controlled_access)
+
+if [ "$controlledAccessStatus" == 'yes' ]; then 
+    if [ -z "$CONTROLLED_ACCESS_DATASETS" ]; then
+        echo "$expName is set as controlled access in $confFile, but the CONTROLLED_ACCESS_DATASETS environment variable is is not set" 1>&2
+        exit 1
+    else
+        datasetInfo=$(grep "^$expName\t" $CONTROLLED_ACCESS_DATASETS)
+        if [ $? -ne 0 ]; then
+            echo "Can't find controlled access info for $expName in $CONTROLLED_ACCESS_DATASETS" 1>&2
+            exit 1
+        else
+            caDir=$(echo -e "$datasetInfo" | awk '{print $2}')
+            caUser=$(echo -e "$datasetInfo" | awk '{print $3}')
+            if [ "$USER" != "$caUser" ]; then
+                echo "I am $USER, not $caUser, I can't quantify this dataset" 1>&2
+                exit 1
+            elif [ ! -d "$caDir" ]; then
+                echo "Controlled access directory $caDir specified in $CONTROLLED_ACCESS_DATASETS for $expName does not exist"
+                exit 1
+            fi 
+        fi
+    fi
+    echo -n "yes"
+else
+    echo -n "no"
+fi
+

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -477,7 +477,7 @@ print.info("Checking the presence of columns... done.")
 ## Check if there are any controlled access runs
 
 controlled.access='no'
-if ( ! is.null(controlled.access.cal) && any(sdrf[[controlled.access.col]] == 'yes')){
+if ( ! is.null(controlled.access.col) && any(sdrf[[controlled.access.col]] == 'yes')){
    controlled.access='yes'
 }
 

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -191,6 +191,7 @@ fastq.col <- getActualColnames('fastq uri', sdrf)
 cell.count.col <- getActualColnames('cell count', sdrf)
 hca.bundle.uuid.col <- getActualColnames('HCA bundle uuid', sdrf)
 hca.bundle.version.col <- getActualColnames('HCA bundle version', sdrf)
+controlled.access.col <- getActualColnames('controlled access', sdrf)
 
 ena.sample.col <- getActualColnames('ena_sample', sdrf)
 organism.col <- getActualColnames('organism', sdrf)
@@ -473,6 +474,13 @@ print.info("Checking the presence of columns... done.")
 # the content
 ################################################################################
 
+## Check if there are any controlled access runs
+
+controlled.access='no'
+if ( ! is.null(controlled.access.cal) && any(sdrf[[controlled.access.col]] == 'yes')){
+   controlled.access='yes'
+}
+
 ## User can specify species, in which case we can discard irrelevant rows
 
 sdrf[[organism.col]] <- gsub(" ","_",tolower(sdrf[[organism.col]]))
@@ -736,7 +744,8 @@ for (species in names(sdrf.by.species.protocol)){
       protocol = tolower(protocol),
       has.spikes = FALSE,
       has.techreps = FALSE,
-      has.strandedness = FALSE
+      has.strandedness = FALSE,
+      has.controlled.access = FALSE
     )
   
     # Filtering could have removed all rows for a species
@@ -813,6 +822,12 @@ for (species in names(sdrf.by.species.protocol)){
       }
     }
   
+    ## Check if there are any controlled access runs
+
+    if ( ! is.null(controlled.access.col) && any(sdrf[[controlled.access.col]] == 'yes')){
+       properties$has.controlled.access=TRUE
+    }
+
     species.protocol.properties[[species]][[protocol]] <- properties 
   }
 }
@@ -907,6 +922,12 @@ configs <- lapply(species_list, function(species){
 
     if (properties$has.strandedness){
       config_fields['strand'] <- strand.col
+    }
+
+    # Do any rows need controlled access analysis?
+
+    if (properties$has.controlled.access){
+      config_fields['controlled_access'] <- controlled.access.col
     }
     
     # For droplet techs, add colums with strighforward statements of the URIs

--- a/bin/submitQuantificationWorkflow.sh
+++ b/bin/submitQuantificationWorkflow.sh
@@ -28,7 +28,6 @@ SUBDIR="$expName/$species/quantification/$protocol"
 
 quantWorkDir=$SCXA_WORK/$SUBDIR
 manualDownloadFolder=$SCXA_DATA/ManuallyDownloaded/$expName
-caParam=
 
 datasetInfo=$(grep "^$expName\t" $CONTROLLED_ACCESS_DATASETS)
 if [ $? -ne 0 ]; then
@@ -39,10 +38,6 @@ if [ $? -ne 0 ]; then
   # directory, but files will be available via symlinks in a flattened
   # directory under /analysis
   manualDownloadFolder=$caDir/analysis/data
-
-  # This setting will be used in the quantification workflows to /require/ the
-  # pre-download status of files.
-  caParam="--controlledAccess=yes"
 fi
 
 mkdir -p $quantWorkDir
@@ -77,7 +72,7 @@ nextflow run \
     --resultsRoot $RESULTS_ROOT \
     --manualDownloadFolder $manualDownloadFolder \
     --transcriptToGene $RESULTS_ROOT/$transcriptToGene \
-    $contIndex $enaSshOption $caParam \
+    $contIndex $enaSshOption \
     -resume \
     $SCXA_WORKFLOW_ROOT/workflow/scxa-workflows/w_${workflow}_quantification/main.nf \
     -work-dir $quantWorkDir \

--- a/bin/submitQuantificationWorkflow.sh
+++ b/bin/submitQuantificationWorkflow.sh
@@ -32,7 +32,7 @@ manualDownloadFolder=$SCXA_DATA/ManuallyDownloaded/$expName
 datasetInfo=$(grep "^$expName$(printf '\t')" $CONTROLLED_ACCESS_DATASETS)
 if [ $? -eq 0 ]; then
   caDir=$(echo -e "$datasetInfo" | awk '{print $2}')
-  quantWorkDir=$caDir/analysis
+  quantWorkDir=$caDir/analysis/nextflow_work
 
   # For controlled access, there may be some substructure to the data
   # directory, but files will be available via symlinks in a flattened

--- a/bin/submitQuantificationWorkflow.sh
+++ b/bin/submitQuantificationWorkflow.sh
@@ -29,7 +29,7 @@ SUBDIR="$expName/$species/quantification/$protocol"
 quantWorkDir=$SCXA_WORK/$SUBDIR
 manualDownloadFolder=$SCXA_DATA/ManuallyDownloaded/$expName
 
-datasetInfo=$(grep "^$expName\t" $CONTROLLED_ACCESS_DATASETS)
+datasetInfo=$(grep "^$expName$(printf '\t')" $CONTROLLED_ACCESS_DATASETS)
 if [ $? -ne 0 ]; then
   caDir=$(echo -e "$datasetInfo" | awk '{print $2}')
   quantWorkDir=$caDir/analysis

--- a/bin/submitQuantificationWorkflow.sh
+++ b/bin/submitQuantificationWorkflow.sh
@@ -27,11 +27,22 @@ SUBDIR="$expName/$species/quantification/$protocol"
 # use
 
 quantWorkDir=$SCXA_WORK/$SUBDIR
+manualDownloadFolder=$SCXA_DATA/ManuallyDownloaded/$expName
+caParam=
 
 datasetInfo=$(grep "^$expName\t" $CONTROLLED_ACCESS_DATASETS)
 if [ $? -ne 0 ]; then
   caDir=$(echo -e "$datasetInfo" | awk '{print $2}')
-  quantWorkDir=$caDir/analysis 
+  quantWorkDir=$caDir/analysis
+
+  # For controlled access, there may be some substructure to the data
+  # directory, but files will be available via symlinks in a flattened
+  # directory under /analysis
+  manualDownloadFolder=$caDir/analysis/data
+
+  # This setting will be used in the quantification workflows to /require/ the
+  # pre-download status of files.
+  caParam="--controlledAccess=yes"
 fi
 
 mkdir -p $quantWorkDir
@@ -64,9 +75,9 @@ nextflow run \
     --protocol $protocol \
     --referenceFasta $RESULTS_ROOT/$referenceFasta \
     --resultsRoot $RESULTS_ROOT \
-    --manualDownloadFolder $SCXA_DATA/ManuallyDownloaded/$expName \
+    --manualDownloadFolder $manualDownloadFolder \
     --transcriptToGene $RESULTS_ROOT/$transcriptToGene \
-    $contIndex $enaSshOption \
+    $contIndex $enaSshOption $caParam \
     -resume \
     $SCXA_WORKFLOW_ROOT/workflow/scxa-workflows/w_${workflow}_quantification/main.nf \
     -work-dir $quantWorkDir \

--- a/bin/submitQuantificationWorkflow.sh
+++ b/bin/submitQuantificationWorkflow.sh
@@ -30,7 +30,7 @@ quantWorkDir=$SCXA_WORK/$SUBDIR
 manualDownloadFolder=$SCXA_DATA/ManuallyDownloaded/$expName
 
 datasetInfo=$(grep "^$expName$(printf '\t')" $CONTROLLED_ACCESS_DATASETS)
-if [ $? -ne 0 ]; then
+if [ $? -eq 0 ]; then
   caDir=$(echo -e "$datasetInfo" | awk '{print $2}')
   quantWorkDir=$caDir/analysis
 

--- a/bin/submitQuantificationWorkflow.sh
+++ b/bin/submitQuantificationWorkflow.sh
@@ -30,7 +30,9 @@ quantWorkDir=$SCXA_WORK/$SUBDIR
 manualDownloadFolder=$SCXA_DATA/ManuallyDownloaded/$expName
 
 datasetInfo=$(grep "^$expName$(printf '\t')" $CONTROLLED_ACCESS_DATASETS)
-if [ $? -eq 0 ]; then
+isCa=$?
+
+if [ $isCa -eq 0 ]; then
   caDir=$(echo -e "$datasetInfo" | awk '{print $2}')
   quantWorkDir=$caDir/analysis/nextflow_work
 
@@ -84,6 +86,8 @@ nextflow run \
 if [ $? -ne 0 ]; then
     echo "Workflow failed for $expName - $species - scxa-${workflow}-quantification-workflow" 1>&2
     exit 1
+elif [ $isCa -eq 0 ]; then
+    rm -rf $quantWorkDir
 fi
             
 popd > /dev/null

--- a/bin/submitQuantificationWorkflow.sh
+++ b/bin/submitQuantificationWorkflow.sh
@@ -21,7 +21,20 @@ done
 
 RESULTS_ROOT=$PWD
 SUBDIR="$expName/$species/quantification/$protocol"     
-mkdir -p $SCXA_WORK/$SUBDIR
+
+# we ran checks earlier to check that we had all we needed in the case of
+# controlled access analysis- so here we just need to retrieve the directory to
+# use
+
+quantWorkDir=$SCXA_WORK/$SUBDIR
+
+datasetInfo=$(grep "^$expName\t" $CONTROLLED_ACCESS_DATASETS)
+if [ $? -ne 0 ]; then
+  caDir=$(echo -e "$datasetInfo" | awk '{print $2}')
+  quantWorkDir=$caDir/analysis 
+fi
+
+mkdir -p $quantWorkDir
 mkdir -p $SCXA_NEXTFLOW/$SUBDIR
 mkdir -p $SCXA_RESULTS/$SUBDIR/reports
 
@@ -56,7 +69,7 @@ nextflow run \
     $contIndex $enaSshOption \
     -resume \
     $SCXA_WORKFLOW_ROOT/workflow/scxa-workflows/w_${workflow}_quantification/main.nf \
-    -work-dir $SCXA_WORK/$SUBDIR \
+    -work-dir $quantWorkDir \
     -with-report $SCXA_RESULTS/$SUBDIR/reports/report.html \
     -with-trace  $SCXA_RESULTS/$SUBDIR/reports/trace.txt \
     -N $SCXA_REPORT_EMAIL \

--- a/main.nf
+++ b/main.nf
@@ -285,6 +285,8 @@ process generate_configs {
 
 process check_controlled_access{
     
+    cache false
+    
     errorStrategy 'ignore'
 
     input:

--- a/main.nf
+++ b/main.nf
@@ -279,7 +279,27 @@ process generate_configs {
     """
 }
 
-CONF_REF_BY_EXP_SPECIES.into{
+// Check for controlled access status. This will exclude an experiment unless
+// all requirements on user, directory etc are in place for a controlled access
+// quantification
+
+process check_controlled_access{
+    
+    errorStrategy 'ignore'
+
+    input:
+        set val(expName), val(species), file(referenceFasta), file(referenceGtf), file(contIndex), file(confFile) from CONF_REF_BY_EXP_SPECIES
+
+    output:
+        set val(expName), val(species), file(referenceFasta), file(referenceGtf), file(contIndex), file(confFile) into CONF_REF_BY_EXP_SPECIES_CA_CHECKED
+
+
+    """
+    checkForControlledAccess.sh $expName $confFile
+    """
+}
+
+CONF_REF_BY_EXP_SPECIES_CA_CHECKED.into{
     CONF_REF_BY_EXP_SPECIES_FOR_QUANT
     CONF_REF_BY_EXP_SPECIES_FOR_TERTIARY
     CONF_REF_BY_EXP_SPECIES_FOR_BUNDLE


### PR DESCRIPTION
Work in progress to allow analysis of controlled access single-cell datasets. These data can only be accessed by the specific permitted user, so quantification of these datasets must be skipped when the the workflow is run by the production user. The user who does have access will run analyses for specific datasets, which will then get picked up as completed bundles (without user-identifiable data) by the production user.

- Add process to skip controlled access datasets for production user
- Supply options to quantification workflows to specify controlled access status and locations for raw data and analysis.

Tested with a smart-seq dataset, works.

Paired with changes in the SMART-seq (https://github.com/ebi-gene-expression-group/scxa-smartseq-quantification-workflow/pull/2) and droplet (https://github.com/ebi-gene-expression-group/scxa-droplet-quantification-workflow/pull/8) workflows.