### PR TITLE
Move to galaxy-workflow-executor for Galaxy CLI functionality

### DIFF
--- a/bin/submitTertiaryWorkflow.sh
+++ b/bin/submitTertiaryWorkflow.sh
@@ -39,7 +39,9 @@ else
     export FLAVOUR=w_smart-seq_clustering
 fi
 
-run_flavour_workflows.sh
+# This script is under /bin of the scxa-workflows repo
+run_tertiary_workflow.sh
+
 if [ $? -eq 0 ]; then
     mkdir -p matrices
                     

--- a/bin/submitTertiaryWorkflow.sh
+++ b/bin/submitTertiaryWorkflow.sh
@@ -40,6 +40,8 @@ else
 fi
 
 # This script is under /bin of the scxa-workflows repo
+
+export state_file=$TMPDIR/${expName}.${species}.galaxystate
 run_tertiary_workflow.sh
 
 if [ $? -eq 0 ]; then

--- a/envs/bioblend.yml
+++ b/envs/bioblend.yml
@@ -1,3 +1,0 @@
-name: bioblend
-dependencies:
-  - bioblend=0.12.0

--- a/envs/galaxy-workflow-executor.yml
+++ b/envs/galaxy-workflow-executor.yml
@@ -1,0 +1,3 @@
+name: galaxy-workflow-executor
+dependencies:
+  - galaxy-workflow-executor=0.2.1

--- a/main.nf
+++ b/main.nf
@@ -954,7 +954,7 @@ if ( tertiaryWorkflow == 'scanpy-galaxy' ) {
         
             maxForks params.maxConcurrentScanpyGalaxy
 
-            conda "${baseDir}/envs/bioblend.yml"
+            conda "${baseDir}/envs/galaxy-workflow-executor.yml"
 
             publishDir "$SCXA_RESULTS/$expName/$species/scanpy", mode: 'copy', overwrite: true
             


### PR DESCRIPTION
This PR moves the CLI Galaxy functionality from being called from a submodule of the scxa-workflows repo to being called from a proper Bioconda package for @pcm32 's galaxy-workflow-executor python package. 

Paired with https://github.com/ebi-gene-expression-group/scxa-workflows/pull/18