### PR TITLE
Add a wrapper script layer for independent execution of experiment-wi…

### DIFF
--- a/bin/submitControlWorkflow.sh
+++ b/bin/submitControlWorkflow.sh
@@ -3,7 +3,7 @@
 usage() { echo "Usage: $0 [-e <experiment ID>] [-q <re-use existing quantifications where present, yes or no>] [-a <re-use existing aggregations where present, yes or no>] [-t <tertiary workflow>] [-u <re-use existing tertiary results where present, yes or no>] [-w <overwrite exising results, yes or no>]"  1>&2; }  
 
 e=
-s=no
+q=no
 t=none
 u=no
 w=no

--- a/bin/submitIndependentControlWorkflows.sh
+++ b/bin/submitIndependentControlWorkflows.sh
@@ -34,6 +34,16 @@ fi
 
 submitted=0
 
+# Fetch the Git SDRFs
+
+if [ ! -d 'metadata' ]; then
+    git clone $SCXA_METADATA_REPO metadata
+fi
+
+pushd metadata > /dev/null
+git pull > /dev/null
+popd > /dev/null
+
 # Submit workflows for any updatated metdata files. The Nextflow workflow
 # itself contains logic for not re-analaysing where it does not need to.
 

--- a/bin/submitIndependentControlWorkflows.sh
+++ b/bin/submitIndependentControlWorkflows.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# This is a further wrapper layer around submitControlWorkflow.sh. That script
+# was initially designed to submit a single Nextflow workflow controlling
+# analysis of all or a batch of SCXA studies. However it can submit the control
+# workflow for one experiment at a time, with independent working directories
+# etc, and this may allow for more effective use of resources than Nextflow
+# processes waiting for a batch to finish before submitting more.
+
+maxExpsToRun=${1:-5}
+
+workflow=scxa-control-workflow
+controlJobSuffix=${SCXA_ENV}_$workflow
+
+export SCXA_RESULTS=$SCXA_WORKFLOW_ROOT/results
+submissionMarker="$SCXA_RESULTS/.submitting"
+
+if [ -e  $submissionMarker ]; then
+    echo "Submission process ongoing"
+else
+    touch $submissionMarker
+fi
+
+currentJobs=$(bjobs -w | grep $controlJobSuffix)
+nJobsRunning=$(echo $currentJobs | wc -l)
+maxToSubmit=$((maxExpsToRun-nJobsRunning))
+
+if [ $nJobsRunning -ge $maxExpsToRun ]; then
+    echo "$nJobsRunning already running, submitting no more\n"
+    exit 0
+else
+    echo "Will sumbit a maximum of $maxToSubmit jobs"
+fi
+
+submitted=0
+
+# Submit workflows for any updatated metdata files. The Nextflow workflow
+# itself contains logic for not re-analaysing where it does not need to.
+
+export PATH=$SCXA_WORKFLOW_ROOT/workflow/scxa-control-workflow/bin:$PATH
+
+while read -r idfFile; do
+    idfFileName=$(basename $idfFile)
+    expId=$(echo $idfFileName | awk -F'.' '{print $1}')
+    sdrfFile=$(dirname $idfFile)/${expId}.sdrf.txt
+    
+    grep -P "$expId\\t" $SCXA_RESULTS/excluded.txt > /dev/null
+    if [ $? -eq 0 ]; then
+        experimentStatus='excluded'
+    else    
+        experimentStatus=$(checkExperimentStatus.sh $expId $sdrfFile $overwrite)
+    fi
+
+    echo "Experiment status for $expId: $experimentStatus"
+    currentlyRunning='false'
+
+    # Check if the jobs is already running
+
+    echo -e "$currentJobs" | grep "${expId}_$controlJobSuffix" > /dev/null
+    if [ $? -eq 0 ]; then
+        currentlyRunning='true'
+        echo "$expId is currently running"
+    fi
+
+    if [ "$currentlyRunning" = 'false' ] && [ $submitted -lt $maxToSubmit ] && [ "$experimentStatus" == 'new' ]; then
+
+        echo "Submitting $expId for re-analysis"
+        $SCXA_WORKFLOW_ROOT/workflow/scxa-control-workflow/bin/submitControlWorkflow.sh -e $expId
+
+        currentJobs=$(bjobs -w | grep $controlJobSuffix)
+        submitted=$((submitted+1))
+
+    fi
+done <<< "$(ls $SCXA_WORKFLOW_ROOT/metadata/*/*/*.idf.txt)"
+
+ls $SCXA_WORKFLOW_ROOT/results/*/*/bundle/MANIFEST | awk -F'/' '{OFS="\t";} {print $(NF-2),$(NF-3),$0}' > $SCXA_RESULTS/all.done.txt
+
+rm $submissionMarker

--- a/bin/submitIndependentControlWorkflows.sh
+++ b/bin/submitIndependentControlWorkflows.sh
@@ -47,7 +47,9 @@ while read -r idfFile; do
     grep -P "$expId\\t" $SCXA_RESULTS/excluded.txt > /dev/null
     if [ $? -eq 0 ]; then
         experimentStatus='excluded'
-    else    
+    else 
+        # Notes: checkExperimentStatus.sh is the same as that used by the
+        # Nextflow workflow, so the logic is kept consistent   
         experimentStatus=$(checkExperimentStatus.sh $expId $sdrfFile $overwrite)
     fi
 

--- a/bin/submitIndependentControlWorkflows.sh
+++ b/bin/submitIndependentControlWorkflows.sh
@@ -122,6 +122,7 @@ while read -r idfFile; do
     fi
 done <<< "$(ls $SCXA_WORKFLOW_ROOT/metadata/*/*/*.idf.txt)"
 
-ls $SCXA_WORKFLOW_ROOT/results/*/*/bundle/MANIFEST | awk -F'/' '{OFS="\t";} {print $(NF-2),$(NF-3),$0}' > $SCXA_RESULTS/all.done.txt
+# List all finished bundles for loading
+ls $SCXA_WORKFLOW_ROOT/results/*/*/bundle/MANIFEST | while read -r l; do dirname $l; done | awk -F'/' '{OFS="\t";} {print $(NF-2),$(NF-1),$0}' > results/all.done.txt
 
 rm $submissionMarker


### PR DESCRIPTION
…se control workflows

Currently, Nextflow handles coordination of different experiment's analyses, which sometimes creates throughput issues as we wait for a single nextflow control process to complete before the next batch of experiments can be processed. This PR adds a sugar shell script that just moves some logic outwards to that the control workflow is executed experiment-wise, and a cron/ jenkins/ whatever can be used to keep a fixed number of experiments in process. 

There is some copy/pasted logic here (the pull of the metadata, argument passing etc), which isn't great. I will tidy up once this script becomes the norm for us. 
