### PR TITLE
Feature/check inferred cell type

### DIFF
--- a/bin/checkExperimentChanges.sh
+++ b/bin/checkExperimentChanges.sh
@@ -7,6 +7,7 @@ expName=$1
 species=$2
 newConfig=$3
 newSdrf=$4
+newCells=$5
 
 # If there's already a MANIFEST then this is a potential re-run. Only do this
 # if the config changes impact on analysis. This will be the case if there's a
@@ -15,8 +16,9 @@ newSdrf=$4
 manifestPath=$SCXA_RESULTS/$expName/$species/bundle/MANIFEST
 oldConfig=$SCXA_CONF/study/$(basename $newConfig)
 oldSdrf=$SCXA_CONF/study/$(basename $newSdrf)
+oldCells=$SCXA_CONF/study/$(basename $newCells)
 
-experimentStatus='changed'
+experimentStatus='unchanged'
 
 if [ -e "$manifestPath" ]; then
     
@@ -27,10 +29,16 @@ if [ -e "$manifestPath" ]; then
 
     diff_configs $newSdrf $oldSdrf
     sdrfDiff=$?
+    
+    diff_configs $newCells $oldCells
+    cellsDiff=$?
 
-    if [ $configDiff -eq 0 ] && [ $sdrfDiff -eq 0 ]; then
-        experimentStatus='unchanged'
+    if [ $configDiff -eq 1 ] || [ $sdrfDiff -eq 1 ]; then
+        experimentStatus='changed'
+    elif [ $cellsDiff -eq 1 ]; then
+        experiment_status='meta_changed'
     fi
 fi
 
 echo -n "$experimentStatus"
+exit 1

--- a/bin/checkExperimentChanges.sh
+++ b/bin/checkExperimentChanges.sh
@@ -38,7 +38,8 @@ if [ -e "$manifestPath" ]; then
     elif [ $cellsDiff -eq 1 ]; then
         experiment_status='meta_changed'
     fi
+else
+    experimentStatus="changed"
 fi
 
 echo -n "$experimentStatus"
-exit 1

--- a/bin/checkExperimentChanges.sh
+++ b/bin/checkExperimentChanges.sh
@@ -1,45 +1,122 @@
 #!/usr/bin/env bash
 
+# This script prints a status that will dictate how the workflow routes
+# analysis. 
+
 scriptDir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $scriptDir/utils.sh
 
 expName=$1
 species=$2
 newConfig=$3
-newSdrf=$4
-newCells=$5
+newMetaForQuant=$4
+newMetaForTertiary=$5
+skipQuantification=$6
+skipAggregation=$7
+skipTertiary=$8
+overWrite=$9
 
 # If there's already a MANIFEST then this is a potential re-run. Only do this
 # if the config changes impact on analysis. This will be the case if there's a
 # difference between new derived files and the old ones.
 
-manifestPath=$SCXA_RESULTS/$expName/$species/bundle/MANIFEST
-oldConfig=$SCXA_CONF/study/$(basename $newConfig)
-oldSdrf=$SCXA_CONF/study/$(basename $newSdrf)
-oldCells=$SCXA_CONF/study/$(basename $newCells)
+resultsDir=$SCXA_RESULTS/$expName/$species
+manifestPath=$resultsDir/bundle/MANIFEST
+
+# Files we use to check the presence of results for individual stages
+
+quantExists=$(pattern_file_exists "$resultsDir/quantification/*/quantification.log")
+aggExists=$(pattern_file_exists "$resultsDir/aggregation/matrices/counts_mtx.zip")
+tertiaryExists=$(pattern_file_exists "$resultsDir/scanpy/clustering_software_versions.txt")
+bundleExists=$(pattern_file_exists $resultsDir/bundle/MANIFEST)
+
+# Default is 'unchanged', which will trigger no analysis. Explicity overwrites,
+# changed config or missing data will trigger analysis processes
 
 experimentStatus='unchanged'
 
-if [ -e "$manifestPath" ]; then
-    
-    # Compare configs and derived SDRFS
+# If overwrite is specified, then re-analyse everything except the explicit skips
 
-    diff_configs $newConfig $oldConfig
-    configDiff=$?
+if [ "$overWrite" == 'yes' ]; then
+    echo "Overwriting" 1>&2
 
-    diff_configs $newSdrf $oldSdrf
-    sdrfDiff=$?
-    
-    diff_configs $newCells $oldCells
-    cellsDiff=$?
-
-    if [ $configDiff -eq 1 ] || [ $sdrfDiff -eq 1 ]; then
-        experimentStatus='changed'
-    elif [ $cellsDiff -eq 1 ]; then
-        experimentStatus='meta_changed'
+    if [ "$skipTertiary" = 'yes' ] && [ $tertiaryExists ]; then
+        experimentStatus='changed_for_bundling'
+    elif [ "$skipAggregation" = 'yes' ] && [ $aggExists ]; then
+        experimentStatus='changed_for_tertiary'
+    elif [ "$skipQuantification" = 'yes' ] && [ $quantExists ]; then
+        experimentStatus='changed_for_aggregation'
+    else 
+        experimentStatus='changed_for_quantification'
     fi
+
 else
-    experimentStatus="changed"
-fi
+    
+    echo "Overwrite not set, checking existing config" 1>&2
+
+    # Where overwrite was not specified, we'll look at the changes to see what need re-doing
+   
+    configDiff=0
+    quantMetaDiff=0
+    tertiaryMetaDiff=0 
+
+    # Has config changed?
+
+    while read -r nc; do
+        oldConfig=$SCXA_CONF/study/$(basename $nc)
+        
+        diff_configs $newConfig/$nc $oldConfig
+        if [ $? -eq 1 ]; then
+            echo "$newConfig/$nc is different to $oldConfig" 1>&2
+            configDiff=1
+            break
+        else
+            echo "$newConfig/$nc is not different to $oldConfig" 1>&2
+        fi
+    done <<< "$(ls $newConfig)"
+
+    # Has quantification-relevant metadata changed?
+    
+    while read -r nmfq; do
+        oldMetaForQuant=$SCXA_CONF/study/$(basename $nmfq)
+        
+        diff_configs $newMetaForQuant/$nmfq $oldMetaForQuant
+        if [ $? -eq 1 ]; then
+            echo "$newMetaForQuant/$nmfq is different to $oldMetaForQuant" 1>&2
+            quantMetaDiff=1
+            break
+        else
+            echo "$newMetaForQuant/$nmfq is not different to $oldMetaForQuant" 1>&2
+        fi
+    done <<< "$(ls $newMetaForQuant)"
+    
+    # Has tertiary-relevant metadata changed?
+
+    while read -r nmft; do
+        oldMetaForTertiary=$SCXA_CONF/study/$(basename $nmft)
+        
+        # Compare configs and derived SDRFS
+
+        diff_configs $newMetaForTertiary/$nmft $oldMetaForTertiary
+        if [ $? -eq 1 ]; then
+            echo "$newMetaForTertiary/$nmft is different to $oldMetaForTertiary" 1>&2
+            tertiaryMetaDiff=1
+            break
+        else
+            echo "$newMetaForTertiary/$nmft is not different to $oldMetaForTertiary" 1>&2
+        fi
+    done <<< "$(ls $newMetaForTertiary)"
+    
+    if [ $configDiff -eq 1 ] || [ $quantMetaDiff -eq 1 ] || [ ! $quantExists ]; then
+        experimentStatus='changed_for_quantification'
+    elif [ ! $aggExists ]; then
+        experimentStatus='changed_for_aggregation'
+    elif [ $tertiaryMetaDiff -eq 1 ] || [ ! $tertiaryExists ]; then
+        experimentStatus='changed_for_tertiary'
+    elif [ ! $bundleExists ]; then
+        experimentStatus='changed_for_bundling'
+    fi
+fi    
+
 
 echo -n "$experimentStatus"

--- a/bin/checkExperimentChanges.sh
+++ b/bin/checkExperimentChanges.sh
@@ -36,7 +36,7 @@ if [ -e "$manifestPath" ]; then
     if [ $configDiff -eq 1 ] || [ $sdrfDiff -eq 1 ]; then
         experimentStatus='changed'
     elif [ $cellsDiff -eq 1 ]; then
-        experiment_status='meta_changed'
+        experimentStatus='meta_changed'
     fi
 else
     experimentStatus="changed"

--- a/bin/checkExperimentStatus.sh
+++ b/bin/checkExperimentStatus.sh
@@ -2,12 +2,15 @@
 
 expName=$1
 sdrfFile=$2
-overwrite=$3
+cellsFile=$3
+overwrite=$4
 
 # Start by assuming a new experiment
 
 newExperiment=1
 bundleManifests=$(ls $SCXA_RESULTS/$expName/*/bundle/MANIFEST 2>/dev/null || true)
+
+cells_filesize=$(stat --printf="%s" $(readlink ${cellsFile}))
 
 # If there are existing bundles for this experiment then just use
 # those, unless the related SDRFs have been updated
@@ -15,7 +18,7 @@ bundleManifests=$(ls $SCXA_RESULTS/$expName/*/bundle/MANIFEST 2>/dev/null || tru
 if [ -n "$bundleManifests" ] && [ "$overwrite" != 'yes' ]; then
     newExperiment=0
     while read -r bundleManifest; do
-        if [ $sdrfFile -nt "$bundleManifest" ]; then
+        if [[ $sdrfFile -nt "$bundleManifest" || ( $cells_filesize -gt 0 && $cellsFile -nt "$bundleManifest" ) ]]; then
             newExperiment=1
             break
         fi

--- a/bin/findCelltypeField.sh
+++ b/bin/findCelltypeField.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+sdrf_file=$1
+cells_file=$2
+cell_type_fields=$3
+
+# Determine if there is a valid cell types file
+
+has_cells=0
+if [ -n "$cells_file" ] && [ -e "$cells_file" ];then
+    cells_filesize=$(stat --printf="%s" $(readlink ${cells_file}))
+    if [ $cells_filesize -gt 0 ]; then
+        has_cells=1
+    fi
+fi
+
+# Loop over the cell types fields, checking in the SDRF and cells files
+
+IFS=',' read -ra ctfs <<< "$cell_type_fields"
+for ctf in "${ctfs[@]}"; do
+    
+    echo "Checking for $ctf" 1>&2
+
+    # Allow for bracketed field in cells file, preceded by any run of non-tab
+    # characters (Factor value etc plus spaces)
+    
+    sdrf_cell_type_field=$(head -n 1 $sdrf_file | grep -io "[^$(echo -e "\t")]*$(echo "\\[$ctf\\]") *")    
+    if [ $? -eq 0 ]; then
+        echo "$sdrf_cell_type_field" | head -n 1 | tr -d '\n'
+        break
+    elif [ $has_cells -eq 1 ]; then
+
+        # Allow for bracketed field in cells file, preceded by any run of
+        # non-tab characters (Factor value etc plus spaces)
+
+        echo "No cell type in SDRF, checking .cells file" 1>&2
+        cells_cell_type_field=$(head -n 1 $cells_file | grep -io "[^$(echo -e "\t")]*$(echo "\\[$ctf\\]") *")    
+        if [ $? -eq 0 ]; then
+            echo "$cells_cell_type_field" | head -n 1 | tr -d '\n'
+            break
+        else
+            
+            # Allow for bare field in cells file, accounting for leading or
+            # trailing spaces
+        
+            cells_cell_type_field=$(head -n 1 $cells_file | grep -io "[$(echo -e "\t")] *$(echo "$ctf") *")    
+            if [ $? -eq 0 ]; then
+                echo "$cells_cell_type_field" | head -n 1 | tr -d '\n' | tr -d '\t'
+                break
+            fi
+        fi
+    fi
+done

--- a/bin/findCelltypeField.sh
+++ b/bin/findCelltypeField.sh
@@ -26,7 +26,7 @@ for ctf in "${ctfs[@]}"; do
     
     sdrf_cell_type_field=$(head -n 1 $sdrf_file | grep -io "[^$(echo -e "\t")]*$(echo "\\[$ctf\\]") *")    
     if [ $? -eq 0 ]; then
-        echo "$sdrf_cell_type_field" | head -n 1 | tr -d '\n'
+        echo -n "$ctf"
         break
     elif [ $has_cells -eq 1 ]; then
 
@@ -36,7 +36,7 @@ for ctf in "${ctfs[@]}"; do
         echo "No cell type in SDRF, checking .cells file" 1>&2
         cells_cell_type_field=$(head -n 1 $cells_file | grep -io "[^$(echo -e "\t")]*$(echo "\\[$ctf\\]") *")    
         if [ $? -eq 0 ]; then
-            echo "$cells_cell_type_field" | head -n 1 | tr -d '\n'
+            echo -n "$ctf"
             break
         else
             
@@ -45,7 +45,7 @@ for ctf in "${ctfs[@]}"; do
         
             cells_cell_type_field=$(head -n 1 $cells_file | grep -io "[$(echo -e "\t")] *$(echo "$ctf") *")    
             if [ $? -eq 0 ]; then
-                echo "$cells_cell_type_field" | head -n 1 | tr -d '\n' | tr -d '\t'
+                echo -n "$ctf"
                 break
             fi
         fi

--- a/bin/retrieveStoredFiles.sh
+++ b/bin/retrieveStoredFiles.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+scriptDir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $scriptDir/utils.sh
+
+expName=$1
+species=$2
+storedType=$3
+filenames=$4
+dest=${5:-'.'}
+
+for file in $filenames; do
+    echo "Looking for $file" 1>&2
+    storedFile=$SCXA_RESULTS/$expName/$species/$storedType/$file
+    fileExists=$(pattern_file_exists "$storedFile")
+
+    if [ $fileExists ]; then
+        ln -s $storedFile $dest
+    else
+        echo "Stored file(s) matching $storedFile does not exist" 1>&2
+        exit 1
+    fi
+done

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -170,9 +170,11 @@ print.info("Loading SDRF ",opt$sdrf_file," ...")
 sdrf <- read.tsv(opt$sdrf_file,header=TRUE,comment.char="",fill=TRUE)
 print.info("Loading SDRF...done.")
 
-print.info("Loading cells ",opt$cells_file," ...")
-cells <- read.tsv(opt$cells_file,header=TRUE,comment.char="",fill=TRUE)
-print.info("Loading cell-wise metadata...done.")
+if ( ! is.null(opt$cells_file)){
+    print.info("Loading cells ",opt$cells_file," ...")
+    cells <- read.tsv(opt$cells_file,header=TRUE,comment.char="",fill=TRUE)
+    print.info("Loading cell-wise metadata...done.")
+}
 
 # Set some variable names we'll be using a lot. getActualColnames() will set
 # things to null when they're not present
@@ -1058,9 +1060,19 @@ configs <- lapply(species_list, function(species){
         }
       }
       
+    }
+
+    # Choose the info we'll be putting in the cells metadata file. This file
+    # will mostly be used to determine when analysis-relevant metdata has
+    # changed between runs. In the case of a droplet experiment without a cells
+    # file, the file of run IDs will not be cell identifiers per se, but will
+    # serve to differentiate this run from a future one where that file is
+    # present.
+    
+    if ( is.droplet.protocol(protocol) && ! is.null(opt$cells_file)){
       # This is a droplet protocol, expect cell type info to be in the cells file
       cells.by.species.protocol[[species]][[protocol]] <<- cells[cells[cells[[run.col]] %in% species.protocol.sdrf[[run.col]]], cell_meta_fields, drop = FALSE]        
-    }else{
+    else{
       # This is not a droplet protocol, expect cell type info to be in the SDRF file
       cells.by.species.protocol[[species]][[protocol]] <<- species.protocol.sdrf[, cell_meta_fields, drop = FALSE]        
     }    

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -202,6 +202,7 @@ hca.bundle.version.col <- getActualColnames('HCA bundle version', sdrf)
 controlled.access.col <- getActualColnames('controlled access', sdrf)
 
 cell_meta_fields <- run.col
+cell.meta.cols <- cells.cell.meta.cols <- NULL
 if (! is.null(opt$cell_meta_fields)){
     cell_meta_fields <- c(cell_meta_fields, unlist(strsplit(opt$cell_meta_fields, ',')))
     cell.meta.cols <- getActualColnames(cell_meta_fields, sdrf)
@@ -1072,7 +1073,7 @@ configs <- lapply(species_list, function(species){
     if ( is.droplet.protocol(protocol) && ! is.null(opt$cells_file)){
       # This is a droplet protocol, expect cell type info to be in the cells file
       cells.by.species.protocol[[species]][[protocol]] <<- cells[cells[cells[[run.col]] %in% species.protocol.sdrf[[run.col]]], cell_meta_fields, drop = FALSE]        
-    else{
+    }else{
       # This is not a droplet protocol, expect cell type info to be in the SDRF file
       cells.by.species.protocol[[species]][[protocol]] <<- species.protocol.sdrf[, cell_meta_fields, drop = FALSE]        
     }    
@@ -1199,8 +1200,13 @@ for (species in names(configs)){
 
     conf.file <- file.path(opt$out_conf, paste0(file_prefix,'.',  opt$name, ".conf"))
     meta.file <- file.path(opt$out_conf, paste0(file_prefix, '.', opt$name, ".metadata.tsv"))
-    sdrf.file <- file.path(opt$out_conf, paste0(file_prefix, '.', opt$name, ".sdrf.txt"))
-    cells.file <- file.path(opt$out_conf, paste0(file_prefix, '.', opt$name, ".cells.txt"))
+
+    # These two files subset the metadata to that which inpacts on
+    # quantification and on tertiary analysis. Changes in these outputs between
+    # runs can be used to detect if changes to metadata require re-analysis
+    
+    sdrf.file <- file.path(opt$out_conf, paste0(file_prefix, '.', opt$name, ".meta_for_quant.txt"))
+    cells.file <- file.path(opt$out_conf, paste0(file_prefix, '.', opt$name, ".meta_for_tertiary.txt"))
   
     config <- configs[[species]][[protocol]]$config
     metadata <- configs[[species]][[protocol]]$metadata

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -24,6 +24,8 @@ option_list <- list(
   make_option(c("--nc_window"), type="numeric", dest="nc_window", default=10, help="Clusters window [default %default]"),  
   make_option(c("-s", "--sdrf"), type="character", dest="sdrf_file", default=NA, help="SDRF file name"),
   make_option(c("-i", "--idf"), type="character", dest="idf_file", default=NULL, help="IDF file name"),
+  make_option(c("-e", "--cells"), type="character", dest="cells_file", default=NULL, help="Cells file name (droplet experiments only)"),
+  make_option(c("-f", "--cell_meta_fields"), type="character", dest="cell_meta_fields", default=NULL, help="Comma-separated list of cell metadata fields important for analysis"),
   make_option(c("--sc"), action="store_true",default=FALSE,dest="is_sc",help="Single cell experiment?. Default is FALSE."),
   make_option(c("-c","--check_only"),action="store_true",dest="check_only",default=FALSE,help="Checks the sdrf/idf but skips the generation of the configuration file."),
   make_option(c("-v","--verbose"),action="store_true",dest="verbose",default=FALSE,help="Produce verbose output."),
@@ -168,6 +170,10 @@ print.info("Loading SDRF ",opt$sdrf_file," ...")
 sdrf <- read.tsv(opt$sdrf_file,header=TRUE,comment.char="",fill=TRUE)
 print.info("Loading SDRF...done.")
 
+print.info("Loading cells ",opt$cells_file," ...")
+cells <- read.tsv(opt$cells_file,header=TRUE,comment.char="",fill=TRUE)
+print.info("Loading cell-wise metadata...done.")
+
 # Set some variable names we'll be using a lot. getActualColnames() will set
 # things to null when they're not present
 
@@ -192,6 +198,12 @@ cell.count.col <- getActualColnames('cell count', sdrf)
 hca.bundle.uuid.col <- getActualColnames('HCA bundle uuid', sdrf)
 hca.bundle.version.col <- getActualColnames('HCA bundle version', sdrf)
 controlled.access.col <- getActualColnames('controlled access', sdrf)
+
+if (! is.null(opt$cell_meta_fields)){
+    cell_meta_fields <- unlist(strsplit(opt$cell_meta_fields, ''))
+    cell.meta.cols <- getActualColnames(cell_meta_fields, sdrf)
+    cell.cell.meta.cols <- getActualColnames(cell_meta_fields, cells)
+}
 
 ena.sample.col <- getActualColnames('ena_sample', sdrf)
 organism.col <- getActualColnames('organism', sdrf)
@@ -738,6 +750,9 @@ names(run.fastq.files) <- unique(sdrf[[run.col]])
 
 sdrf.by.species.protocol <- lapply(split(sdrf, sdrf[[organism.col]]), function(x) split(x, x[[protocol.col]]) )
 
+# Filter any cells file to match the protocol-wise data
+cells.by.species.protocol <- list()
+
 # Run the checks first
 
 species.protocol.properties <- list()
@@ -756,6 +771,7 @@ for (species in names(sdrf.by.species.protocol)){
       has.techreps = FALSE,
       has.strandedness = FALSE,
       has.controlled.access = FALSE
+      has.cell.meta = FALSE
     )
   
     # Filtering could have removed all rows for a species
@@ -838,6 +854,12 @@ for (species in names(sdrf.by.species.protocol)){
        properties$has.controlled.access=TRUE
     }
 
+    # Check if there are inferred cell types in the SDRF
+
+    if ( (! is.null(cell.meta.cols)) || (! is.null(cells.cell.meta.cols))){
+        properties$has.cell.meta=TRUE
+    }
+
     species.protocol.properties[[species]][[protocol]] <- properties 
   }
 }
@@ -887,6 +909,7 @@ configs <- lapply(species_list, function(species){
     )
 
     config_fields <- c(run = run.col, layout = library.layout.col)
+    
     if (!  is.droplet.protocol(protocol)){
       if ( length(fastq.fields) > 1 ){
         perror('Multiple fastq fields on non-droplet experiment')
@@ -1033,6 +1056,12 @@ configs <- lapply(species_list, function(species){
           config_fields[field_label] <- field_name
         }
       }
+      
+      # This is a droplet protocol, expect cell type info to be in the cells file
+      cells.by.species.protocol[[species]][[protocol]] <<- cells[cells[cells[[run.col]] %in% species.protocol.sdrf[[run.col]]], c(run.col, cell_meta_fields), drop = FALSE]        
+    }else{
+      # This is not a droplet protocol, expect cell type info to be in the SDRF file
+      cells.by.species.protocol[[species]][[protocol]] <<- species.protocol.sdrf[, c(run.col, cell_meta_fields), drop = FALSE]        
     }    
 
     # Record field containing cell counts, where present
@@ -1054,7 +1083,7 @@ configs <- lapply(species_list, function(species){
 
     # Re-save the tweaked SDRF for output
     sdrf.by.species.protocol[[species]][[protocol]] <<- species.protocol.sdrf[, config_fields]        
- 
+    
     # Put spikes in if present
 
     config <- c (config, spikes)
@@ -1158,6 +1187,7 @@ for (species in names(configs)){
     conf.file <- file.path(opt$out_conf, paste0(file_prefix,'.',  opt$name, ".conf"))
     meta.file <- file.path(opt$out_conf, paste0(file_prefix, '.', opt$name, ".metadata.tsv"))
     sdrf.file <- file.path(opt$out_conf, paste0(file_prefix, '.', opt$name, ".sdrf.txt"))
+    cells.file <- file.path(opt$out_conf, paste0(file_prefix, '.', opt$name, ".cells.txt"))
   
     config <- configs[[species]][[protocol]]$config
     metadata <- configs[[species]][[protocol]]$metadata
@@ -1171,6 +1201,7 @@ for (species in names(configs)){
       pinfo("Created ", meta.file)
     }
     write.tsv(sdrf.by.species.protocol[[species]][[protocol]], file=sdrf.file)
+    write.tsv(cells.by.species.protocol[[species]][[protocol]], file=cells.file)
     writeLines(config, con = conf.file)
     pinfo("Created ", conf.file)
   }

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -206,7 +206,9 @@ cell.meta.cols <- cells.cell.meta.cols <- NULL
 if (! is.null(opt$cell_meta_fields)){
     cell_meta_fields <- c(cell_meta_fields, unlist(strsplit(opt$cell_meta_fields, ',')))
     cell.meta.cols <- getActualColnames(cell_meta_fields, sdrf)
-    cells.cell.meta.cols <- getActualColnames(cell_meta_fields, cells)
+    if ( ! is.null(opt$cells_file)){
+        cells.cell.meta.cols <- getActualColnames(cell_meta_fields, cells)
+    }
 }
 
 ena.sample.col <- getActualColnames('ena_sample', sdrf)
@@ -1072,10 +1074,11 @@ configs <- lapply(species_list, function(species){
     
     if ( is.droplet.protocol(protocol) && ! is.null(opt$cells_file)){
       # This is a droplet protocol, expect cell type info to be in the cells file
-      cells.by.species.protocol[[species]][[protocol]] <<- cells[cells[cells[[run.col]] %in% species.protocol.sdrf[[run.col]]], cell_meta_fields, drop = FALSE]        
+      cells.by.species.protocol[[species]][[protocol]] <<- cells[cells[cells[[run.col]] %in% species.protocol.sdrf[[run.col]]], cells.cell.meta.cols, drop = FALSE]        
     }else{
       # This is not a droplet protocol, expect cell type info to be in the SDRF file
-      cells.by.species.protocol[[species]][[protocol]] <<- species.protocol.sdrf[, cell_meta_fields, drop = FALSE]        
+        print(paste("selecting", cell.meta.cols))
+      cells.by.species.protocol[[species]][[protocol]] <<- species.protocol.sdrf[, cell.meta.cols, drop = FALSE]        
     }    
 
     # Record field containing cell counts, where present
@@ -1223,6 +1226,7 @@ for (species in names(configs)){
     write.tsv(cells.by.species.protocol[[species]][[protocol]], file=cells.file)
     writeLines(config, con = conf.file)
     pinfo("Created ", conf.file)
+    pinfo("Created ", cells.file)
   }
 }
 

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -199,10 +199,11 @@ hca.bundle.uuid.col <- getActualColnames('HCA bundle uuid', sdrf)
 hca.bundle.version.col <- getActualColnames('HCA bundle version', sdrf)
 controlled.access.col <- getActualColnames('controlled access', sdrf)
 
+cell_meta_fields <- run.col
 if (! is.null(opt$cell_meta_fields)){
-    cell_meta_fields <- unlist(strsplit(opt$cell_meta_fields, ''))
+    cell_meta_fields <- c(cell_meta_fields, unlist(strsplit(opt$cell_meta_fields, ',')))
     cell.meta.cols <- getActualColnames(cell_meta_fields, sdrf)
-    cell.cell.meta.cols <- getActualColnames(cell_meta_fields, cells)
+    cells.cell.meta.cols <- getActualColnames(cell_meta_fields, cells)
 }
 
 ena.sample.col <- getActualColnames('ena_sample', sdrf)
@@ -770,7 +771,7 @@ for (species in names(sdrf.by.species.protocol)){
       has.spikes = FALSE,
       has.techreps = FALSE,
       has.strandedness = FALSE,
-      has.controlled.access = FALSE
+      has.controlled.access = FALSE,
       has.cell.meta = FALSE
     )
   
@@ -1058,10 +1059,10 @@ configs <- lapply(species_list, function(species){
       }
       
       # This is a droplet protocol, expect cell type info to be in the cells file
-      cells.by.species.protocol[[species]][[protocol]] <<- cells[cells[cells[[run.col]] %in% species.protocol.sdrf[[run.col]]], c(run.col, cell_meta_fields), drop = FALSE]        
+      cells.by.species.protocol[[species]][[protocol]] <<- cells[cells[cells[[run.col]] %in% species.protocol.sdrf[[run.col]]], cell_meta_fields, drop = FALSE]        
     }else{
       # This is not a droplet protocol, expect cell type info to be in the SDRF file
-      cells.by.species.protocol[[species]][[protocol]] <<- species.protocol.sdrf[, c(run.col, cell_meta_fields), drop = FALSE]        
+      cells.by.species.protocol[[species]][[protocol]] <<- species.protocol.sdrf[, cell_meta_fields, drop = FALSE]        
     }    
 
     # Record field containing cell counts, where present

--- a/bin/submitBundleWorkflow.sh
+++ b/bin/submitBundleWorkflow.sh
@@ -9,15 +9,16 @@ referenceGtf=$6
 tertiaryWorkflow=$7
 condensedSdrf=$8
 cellMeta=$9
-rawMatrix=${10}
-filteredMatrix=${11}
-normalisedMatrix=${12}
-tpmMatrix=${13}
-clusters=${14}
-markersDir=${15}
-tsneDir=${16}
-umapDir=${17}
-softwareReport=${18}
+cellTypeField=${10}
+rawMatrix=${11}
+filteredMatrix=${12}
+normalisedMatrix=${13}
+tpmMatrix=${14}
+clusters=${15}
+markersDir=${16}
+tsneDir=${17}
+umapDir=${18}
+softwareReport=${19}
 
 RESULTS_ROOT=$PWD
 SUBDIR="$expName/$species/bundle"     
@@ -49,6 +50,7 @@ nextflow run \
     --resultsRoot $RESULTS_ROOT \
     --protocolList ${protocolList} \
     --cellMetadata ${cellMeta} \
+    --cellTypeField ${cellTypeField} \
     --condensedSdrf ${condensedSdrf} \
     --rawMatrix ${rawMatrix} $TPM_OPTIONS \
     --referenceFasta $referenceFasta \

--- a/bin/submitQuantificationWorkflow.sh
+++ b/bin/submitQuantificationWorkflow.sh
@@ -9,7 +9,8 @@ sdrfFile=$6
 referenceFasta=$7
 transcriptToGene=$8
 contaminationIndex=$9
-enaSshUser=$10
+enaSshUser=${10}
+privacyStatus=${11}
 
 # Remove existing results downstrea of this step
 
@@ -40,6 +41,19 @@ if [ $isCa -eq 0 ]; then
   # directory, but files will be available via symlinks in a flattened
   # directory under /analysis
   manualDownloadFolder=$caDir/analysis/data
+
+elif [ "$privacyStatus" != 'public' ]; then
+    
+  if [ -z "$SCXA_PRIVATE_PATH" ]; then
+    echo "$expName is a private experiment, but SCXA_PRIVATE_PATH is not set in the environment" 1>&2
+    exit 1
+  elif [ "$privacyStatus" != 'private' ]; then
+    echo "Invalid privacy status: '$privacyStatus'"
+    exit 1
+  fi
+
+  expType=$(echo -n "$expName" | awk -F '-' '{print $2}')
+  manualDownloadFolder=$SCXA_PRIVATE_PATH/$expType/$expName
 fi
 
 mkdir -p $quantWorkDir

--- a/bin/submitTertiaryWorkflow.sh
+++ b/bin/submitTertiaryWorkflow.sh
@@ -7,8 +7,9 @@ species=$2
 countMatrix=$3
 referenceGtf=$4
 cellMetadata=$5
-isDroplet=$6
-galaxyCredentials=$7
+celltypeField=$6
+isDroplet=$7
+galaxyCredentials=$8
 
 rm -rf $SCXA_RESULTS/$expName/$species/bundle
                 
@@ -28,6 +29,7 @@ export matrix_file=${zipdir}/matrix.mtx.gz
 export genes_file=${zipdir}/genes.tsv.gz
 export barcodes_file=${zipdir}/barcodes.tsv.gz
 export cell_meta_file=$cellMetadata
+export cell_type_field=$(echo $celltypeField | sed "s/ /_/g")
 export tpm_filtering='False'
 export create_conda_env=no
 export GALAXY_CRED_FILE=$galaxyCredentials
@@ -81,6 +83,6 @@ if [ $? -eq 0 ]; then
     fi
 
     if [ -e 'celltype_markers.tsv' ]; then
-        mv celltype_markers.tsv markers
+        mv celltype_markers.tsv markers/${celltypeField}_markers.tsv
     fi
 fi 

--- a/bin/submitTertiaryWorkflow.sh
+++ b/bin/submitTertiaryWorkflow.sh
@@ -85,4 +85,6 @@ if [ $? -eq 0 ]; then
     if [ -e 'celltype_markers.tsv' ]; then
         mv celltype_markers.tsv markers/${celltypeField}_markers.tsv
     fi
+
+    rm -f state_file
 fi 

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -19,6 +19,28 @@ diff_configs (){
     file1=$1
     file2=$2
 
-    diff -I '^//' $file1 $file2 > /dev/null 2>&1
-    return $? 
+    diffStat=
+
+    if [ -e $file1 ] && [ -e $file2 ]; then
+        diff -I '^//' $file1 $file2 > /dev/null 2>&1
+        diffStat=$?
+    else
+        diffStat=1
+    fi
+
+    return $diffStat
+}
+
+# Pattern file exits
+
+pattern_file_exists(){
+    pattern=$1
+
+    ls $pattern > /dev/null 2>&1
+    fexists=$?
+    if [ $fexists -eq 0 ]; then
+        echo true
+    fi
+
+    return $fexists    
 }

--- a/main.nf
+++ b/main.nf
@@ -508,7 +508,7 @@ process reset_experiment{
         set val(tag), val(expName), val(species), val(protocol), file("in/*"), file("in/*"), val(expStatus) from CHANGED_FOR_QUANT
 
     output:
-        set val(tag), file("*.conf"), file("*.meta_for_quant.txt") into NEW_OR_RESET_EXPERIMENTS
+        set val(tag), file("*.conf"), file("*.meta_for_quant.txt"), file("*.meta_for_tertiary.txt") into NEW_OR_RESET_EXPERIMENTS
         
     """
         # Only remove downstream results where we're not re-using them
@@ -527,7 +527,7 @@ process reset_experiment{
 
         # Now we've removed the results, link the results for publishing
 
-        cp -P in/*.meta_for_quant.txt in/*conf .
+        cp -P in/*.meta_for_quant.txt in/*conf in/*.meta_for_tertiary.txt .
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -542,7 +542,7 @@ process prepare_reference {
     errorStrategy { task.attempt<=3 ? 'retry' : 'finish' }
 
     input:
-        set val(tag), file(confFile), file(metaForQuant), file(referenceFasta), file(referenceGtf), val(contaminationIndex) from NEW_OR_RESET_EXPERIMENTS.join(TAGGED_REFERENCES)
+        set val(tag), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex) from NEW_OR_RESET_EXPERIMENTS.join(TAGGED_REFERENCES)
     
     output:
         set val(tag), file("out/*.fa.gz"), file("out/*.gtf.gz"), val(contaminationIndex) into PREPARED_REFERENCES

--- a/main.nf
+++ b/main.nf
@@ -527,7 +527,7 @@ process reset_experiment{
 
         # Now we've removed the results, link the results for publishing
 
-        cp -P in/*.sdrf.txt in/*conf .
+        cp -P in/*.meta_for_quant.txt in/*conf .
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -517,6 +517,8 @@ NOT_CHANGED_EXPERIMENTS
 
 process reset_experiment{
     
+    cache 'deep'
+   
     input:
         set val(expName), val(species), val(espTags), val(expStatus) from NEW_OR_CHANGED_EXPERIMENTS
 
@@ -535,6 +537,8 @@ process reset_experiment{
         else
             reset_stages="bundle"
         fi
+
+        rm -f $TMPDIR/${expName}.${species}.galaxystate
 
         for stage in \$reset_stages; do
             rm -rf $SCXA_RESULTS/$expName/$species/\$stage

--- a/main.nf
+++ b/main.nf
@@ -320,6 +320,7 @@ ESP_TAGS.into{
     ESP_TAGS_FOR_QUANT
     ESP_TAGS_FOR_AGGR
     ESP_TAGS_FOR_IS_DROPLET
+    ESP_TAGS_FOR_PRIVACY_CHECK
 }
 
 // Make comma-separated list of the protocols for each exp/species combo
@@ -577,6 +578,7 @@ TO_QUANTIFY
     .into{
         TO_QUANTIFY_FOR_QUANT
         TO_QUANTIFY_FOR_REFERENCE
+        TO_QUANTIFY_FOR_PRIVACY_CHECK
     }
 
 NOT_CHANGED_FOR_QUANT
@@ -694,6 +696,24 @@ process reuse_tertiary {
 ////////////////////////////////////////////////////////////////
 // Processes to derive new results
 ////////////////////////////////////////////////////////////////
+
+// Is experiment public or private?
+
+process check_privacy {
+
+    executor 'local'
+
+    input:
+        set val(espTag), val(expName), val(species), val(protocol) from TO_QUANTIFY_FOR_PRIVACY_CHECK.join(ESP_TAGS_FOR_PRIVACY_CHECK)
+
+    output:
+        set val(espTag), stdout into PRIVACY_STATUS
+
+    """
+    privacyStatus=\$(wget -O - http://peach.ebi.ac.uk:8480/api/privacy.txt?acc=${expName} 2>/dev/null | tr "\\t" "\\n" | awk -F':' '/privacy/ {print \$2}')
+    echo -n "\$privacyStatus"
+    """
+}
 
 // Symlink to correct reference file, re-using the reference from last
 // quantification where appropriate
@@ -862,6 +882,7 @@ TO_QUANTIFY_FOR_QUANT
     .join(ANALYSIS_META_FOR_QUANT)
     .join(CLEANED_REFERENCES)
     .join(TRANSCRIPT_TO_GENE_QUANT)
+    .join(PRIVACY_STATUS)
     .set{
         QUANT_INPUTS
     }
@@ -892,7 +913,7 @@ process smart_quantify {
     maxRetries 10
     
     input:
-        set val(espTag), val(isDroplet), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex), file(transcriptToGene) from SMART_INPUTS
+        set val(espTag), val(isDroplet), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex), file(transcriptToGene), val(privacyStatus) from SMART_INPUTS
         val flag from INIT_DONE_SMART
 
     output:
@@ -901,7 +922,7 @@ process smart_quantify {
         file('quantification.log')    
 
     """
-    submitQuantificationWorkflow.sh 'smart-seq' "$expName" "$species" "$protocol" "$confFile" "$metaForQuant" "$referenceFasta" "$transcriptToGene" "$contaminationIndex" "$enaSshUser"
+    submitQuantificationWorkflow.sh 'smart-seq' "$expName" "$species" "$protocol" "$confFile" "$metaForQuant" "$referenceFasta" "$transcriptToGene" "$contaminationIndex" "$enaSshUser" "$privacyStatus"
     """
 }
 
@@ -921,7 +942,7 @@ process droplet_quantify {
     errorStrategy { task.attempt<=5 ? 'retry' : 'ignore' }
 
     input:
-        set val(espTag), val(isDroplet), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex), file(transcriptToGene) from DROPLET_INPUTS
+        set val(espTag), val(isDroplet), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex), file(transcriptToGene), val(privacyStatus) from DROPLET_INPUTS
         val flag from INIT_DONE_DROPLET
 
     output:
@@ -929,7 +950,7 @@ process droplet_quantify {
         file('quantification.log')    
 
     """
-    submitQuantificationWorkflow.sh 'droplet' "$expName" "$species" "$protocol" "$confFile" "$metaForQuant" "$referenceFasta" "$transcriptToGene" "$contaminationIndex" "$enaSshUser"
+    submitQuantificationWorkflow.sh 'droplet' "$expName" "$species" "$protocol" "$confFile" "$metaForQuant" "$referenceFasta" "$transcriptToGene" "$contaminationIndex" "$enaSshUser" "$privacyStatus"
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -453,7 +453,7 @@ process check_experiment_changed{
         set val(tag), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary) from TAGS_FOR_CHANGEDCHECK.join(CONF_FOR_CHANGEDCHECK)
 
     output:
-        set val(tag), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), stdout into COMPILED_DERIVED_CONFIG_WITH_STATUS
+        set val(tag), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), stdout into COMPILED_DERIVED_CONFIG_WITH_STATUS
         
 
     """
@@ -465,14 +465,14 @@ NEW_OR_CHANGED_EXPERIMENTS = Channel.create()
 NOT_CHANGED_EXPERIMENTS = Channel.create()
 
 COMPILED_DERIVED_CONFIG_WITH_STATUS.choice( NEW_OR_CHANGED_EXPERIMENTS, NOT_CHANGED_EXPERIMENTS ) {a -> 
-    a[5] == 'unchanged' ? 1 : 0
+    a[7] == 'unchanged' ? 1 : 0
 }
 
 CHANGED_FOR_QUANT = Channel.create()
 CHANGED_FOR_TERTIARY_ONLY = Channel.create()
 
 NEW_OR_CHANGED_EXPERIMENTS.choice( CHANGED_FOR_QUANT, CHANGED_FOR_TERTIARY_ONLY ) {a -> 
-    a[5] == 'meta_changed' ? 1 : 0
+    a[7] == 'meta_changed' ? 1 : 0
 }
 
 // Generate bundle lines for the things updated but not actually changed for
@@ -505,7 +505,7 @@ process reset_experiment{
     publishDir "$SCXA_CONF/study", mode: 'copy', overwrite: true
 
     input:
-        set val(tag), val(expName), val(species), val(protocol), file("in/*"), file("in/*"), val(expStatus) from CHANGED_FOR_QUANT
+        set val(tag), val(expName), val(species), val(protocol), file("in/*"), file("in/*"), file("in/*"), val(expStatus) from CHANGED_FOR_QUANT
 
     output:
         set val(tag), file("*.conf"), file("*.meta_for_quant.txt"), file("*.meta_for_tertiary.txt") into NEW_OR_RESET_EXPERIMENTS

--- a/main.nf
+++ b/main.nf
@@ -681,7 +681,7 @@ process reuse_tertiary {
     executor 'local'
     
     input:
-        set val(esTag), val(expStatus), val(expName), val(species) from NOT_CHANGED_FOR_TERTIARY_FOR_REUSE_TERTIARY.join(ES_TAGS_FOR_REUSE_TERTIARY)
+        set val(esTag), val(expName), val(species) from NOT_CHANGED_FOR_TERTIARY_FOR_REUSE_TERTIARY.join(ES_TAGS_FOR_REUSE_TERTIARY)
     
     output:
         set val(esTag), file("matrices/raw_filtered.zip"), file("matrices/filtered_normalised.zip"), file("clusters_for_bundle.txt"), file("umap"), file("tsne"), file("markers"), file('clustering_software_versions.txt') into REUSED_TERTIARY_RESULTS
@@ -1186,14 +1186,11 @@ NEW_TERTIARY_RESULTS
     .join(PROTOCOLS_BY_EXP_SPECIES)                                                     // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList
     .join(CONF_BY_EXP_SPECIES_FOR_BUNDLE)                                               // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList, confFile
     .join(NEW_COUNT_MATRICES_FOR_BUNDLING.concat(REUSED_COUNT_MATRICES_FOR_BUNDLING))   // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList, confFile, rawMatrix
-    //.subscribe { println it }
     .join(NEW_TPM_MATRICES.concat(REUSED_TPM_MATRICES), remainder: true)                                 // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList, confFile, rawMatrix, tpmMatrix
     .join(REFERENCES_FOR_BUNDLING)                                                      // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList, confFile, rawMatrix, tpmMatrix, referenceFasta, referenceGtf, contIndex
     .join(CONDENSED_FOR_BUNDLING.concat(REUSED_CONDENSED))                              // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList, confFile, rawMatrix, tpmMatrix, referenceFasta, referenceGtf, contIndex, condensedSdrf
     .join(MATCHED_META_FOR_BUNDLING)                                                    // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList, confFile, rawMatrix, tpmMatrix, referenceFasta, referenceGtf, contIndex, condensedSdrf, cellMetadata 
     .set{BUNDLE_INPUTS}
-
-//BUNDLE_INPUTS = Channel.create()
 
 process bundle {
     

--- a/main.nf
+++ b/main.nf
@@ -269,12 +269,17 @@ process generate_configs {
         set val(expName), val(species), file("*.${species}.${expName}.sdrf.txt"), file("*.${species}.${expName}.cells.txt") into CONFSDRF_BY_EXP_SPECIES
 
     """
+    # Cells file will be empty (from reminder: true above) for some experiments
+    cells_options=
+    cells_filesize=$(stat --printf="%s" $(readlink ${cellsFile}))
+    if [ $cells_filesize -gt 0 ]; then
+        cells_options="--cells=$cellsFile --cell_meta_fields="$params.cellAnalysisFields""
+    fi
+
     mkdir -p tmp
     sdrfToNfConf.R \
         --sdrf=\$(readlink $sdrfFile) \
-        --idf=$idfFile \
-        --cells=$cellsFile \
-        --cell_meta_fields=$params.cellAnalysisFields \
+        --idf=$idfFile $cells_options\
         --name=$expName \
         --verbose \
         --out_conf \$(pwd)

--- a/main.nf
+++ b/main.nf
@@ -17,18 +17,28 @@ if ( params.containsKey('galaxyCredentials')){
 }
 
 skipQuantification = 'no'
-if ( params.containsKey('skipQuantification') && params.skipQuantification == 'yes'){
-    skipQuantification = 'yes'
-}
-
 skipAggregation = 'no'
-if ( params.containsKey('skipAggregation') && params.skipAggregation == 'yes'){
+skipTertiary = 'no'
+
+if ( params.containsKey('skipTertiary') && params.skipTertiary == 'yes'){
+    
+    // Skipping tertiary means that for consistency we must also skip the
+    // quantification and aggregations
+    
+    skipTertiary = 'yes'
+    skipQuantification = 'yes'
     skipAggregation = 'yes'
 }
+else if ( params.containsKey('skipAggregation') && params.skipAggregation == 'yes'){ 
 
-skipTertiary = 'no'
-if ( params.containsKey('skipTertiary') && params.skipTertiary == 'yes'){
-    skipTertiary = 'yes'
+    // Skipping aggregation implies skipping quantifiction
+    
+    skipQuantification = 'yes'
+    skipAggregation = 'yes'
+
+} else if ( params.containsKey('skipQuantification') && params.skipQuantification == 'yes'){
+    
+    skipQuantification = 'yes'
 }
 
 // Now we pick the SDRFs to use
@@ -101,24 +111,8 @@ COMPILED_METADATA_WITH_STATUS.choice( UPDATED_EXPERIMENTS, NOT_UPDATED_EXPERIMEN
     a[4] == 'old' ? 1 : 0
 }
 
-process get_not_updated_bundles {
-
-    input:
-        val expName from NOT_UPDATED_EXPERIMENTS.map{r -> r[0]}
-
-    output:
-        file('bundleLines.txt') into NOT_UPDATED_BUNDLES
-
-    """
-        ls \$SCXA_RESULTS/$expName/*/bundle/MANIFEST | while read -r l; do
-            species=\$(echo \$l | awk -F'/' '{print \$(NF-2)}' | tr -d \'\\n\')
-            echo -e "$expName\\t\$species\\t$SCXA_RESULTS/$expName/\$species/bundle"
-        done > bundleLines.txt
-
-    """
-}
-
-// Check the update status of the experiment
+// Split the experiment by species- multiple-sepcies experiments will produce
+// multiple bundles
 
 process split_by_species {
 
@@ -137,87 +131,11 @@ process split_by_species {
 
 MULTISPECIES_META
     .transpose()
-    .map{ row-> tuple( row[0], row[2].toString().split('\\.')[1], row[1], row[2], row[3] ) }
+    .map{ row -> tuple( row[0], row[2].toString().split('\\.')[1], row[1], row[2], row[3] ) }
     .into{
         META_WITH_SPECIES
         META_FOR_REF
     }    
-
-// Locate reference files. If we're skipping quantification, make sure to
-// select the reference used previously
-
-if ( skipQuantification == 'yes'){
-
-    process reuse_reference{
-        
-        input:
-            set val(expName), val(species) from META_FOR_REF.map{ r -> tuple(r[0], r[1]) }
-        
-        output:
-            set val(expName), val(species), file("*.fa.gz"), file("*.gtf.gz"), stdout into REFERENCES
-
-        """
-        ln -s $SCXA_RESULTS/$expName/$species/reference/*.fa.gz
-        ln -s $SCXA_RESULTS/$expName/$species/reference/*.gtf.gz
-        """
-    }
-
-}else{
-    process add_reference {
-
-        conda 'pyyaml' 
-        
-        cache 'deep'
-        
-        errorStrategy { task.attempt<=3 ? 'retry' : 'finish' }
-            
-        publishDir "$SCXA_RESULTS/$expName/$species/reference", mode: 'copy', overwrite: true
-
-        input:
-            set val(expName), val(species) from META_FOR_REF.map{ r -> tuple(r[0], r[1]) }
-        
-        output:
-            set val(expName), val(species), file("*.fa.gz"), file("*.gtf.gz"), stdout into REFERENCES
-
-        """
-        # Use references from the ISL setup
-        if [ -n "\$ISL_GENOMES" ] && [ "\$IRAP_CONFIG_DIR" != '' ] && [ "\$IRAP_DATA" != '' ]; then
-            irap_species_conf=$IRAP_CONFIG_DIR/${species}.conf
-            if [ ${params.islReferenceType} = 'newest' ]; then
-                gtf_pattern=\$(basename \$(cat \$ISL_GENOMES | grep $species | awk '{print \$6}') | sed 's/RELNO/\\*/')
-                cdna_pattern=\$(basename \$(cat \$ISL_GENOMES | grep $species | awk '{print \$5}') | sed 's/RELNO/\\*/' | sed 's/.fa.gz/.\\*.fa.gz/') 
-
-                cdna_gtf=\$(ls \$IRAP_DATA/reference/${species}/\$gtf_pattern | sort -rV | head -n 1)
-                cdna_fasta=\$(ls \$IRAP_DATA/reference/${species}/\$cdna_pattern | sort -rV | head -n 1)
-            else
-                cdna_fasta=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf cdna_file)   
-                cdna_gtf=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf gtf_file)   
-            fi
-            if [ ! -e "\$cdna_fasta" ]; then
-                echo "Fasta file \$cdna_fasta does not exist" 1>&2
-                exit 1
-            elif [ ! -e "\$cdna_gtf" ]; then
-                echo "GTF file \$cdna_gtf does not exist" 1>&2
-                exit 1
-            fi
-            contamination_index=\$(parseIslConfig.sh \$irap_species_conf cont_index)  
-        else
-            echo "All of environment variables ISL_GENOMES, IRAP_CONFIG_DIR AND IRAP_DATA must be set" 1>&2
-            exit 1
-        fi
-       
-        echo -n "\$contamination_index"
-        ln -s \$cdna_fasta
-        ln -s \$cdna_gtf
-        """
-    }
-}
-
-REFERENCES.into{
-    REFERENCES_FOR_QUANT
-    REFERENCES_FOR_TERTIARY
-    REFERENCES_FOR_BUNDLE
-}
 
 // Need to adjust the IDF to match the SDRF. This is necessary for when we're
 // doing the SDRF condensation later
@@ -228,7 +146,8 @@ process adjust_idf_for_sdrf{
         set val(expName), val(species), file(idfFile), file(sdrfFile), file(cellsFile) from META_WITH_SPECIES
 
     output:
-        set val(expName), val(species), file("${expName}.${species}.idf.txt"), file(sdrfFile), file(cellsFile) into META_WITH_SPECIES_IDF
+        set val("${expName}-${species}"), file("${expName}.${species}.idf.txt"), file(sdrfFile), file(cellsFile) into META_WITH_SPECIES_IDF
+        set val("${expName}-${species}"), val(expName), val(species) into ES_TAGS
 
     """
     outFile="${expName}.${species}.idf.txt"
@@ -236,6 +155,18 @@ process adjust_idf_for_sdrf{
     sed -i 's/${expName}.sdrf.txt/${expName}.${species}.sdrf.txt/' \${outFile}.tmp  
     mv \${outFile}.tmp \${outFile}
     """
+}
+
+// Experiment/ species tags
+
+ES_TAGS.unique().into{
+    ES_TAGS_FOR_CONFIG
+    ES_TAGS_FOR_CONDENSE
+    ES_TAGS_FOR_META_MATCHING
+    ES_TAGS_FOR_TERTIARY
+    ES_TAGS_FOR_REUSE_TERTIARY
+    ES_TAGS_FOR_REUSE_AGG
+    ES_TAGS_FOR_BUNDLING
 }
 
 META_WITH_SPECIES_IDF
@@ -262,33 +193,63 @@ process generate_configs {
     conda 'r-optparse r-data.table r-workflowscriptscommon pyyaml'
 
     input:
-        set val(expName), val(species), file(idfFile), file(sdrfFile), file(cellsFile), file(referenceFasta), file(referenceGtf), file(contIndex) from META_WITH_SPECIES_FOR_QUANT.join(REFERENCES_FOR_QUANT, by: [0,1])
+        set val(esTag), val(expName), val(species), file(idfFile), file(sdrfFile), file(cellsFile) from  ES_TAGS_FOR_CONFIG.join(META_WITH_SPECIES_FOR_QUANT)
 
     output:
-        set val(expName), val(species), file(referenceFasta), file(referenceGtf), file(contIndex), file("*.${species}.${expName}.conf") into CONF_REF_BY_EXP_SPECIES
-        set val(expName), val(species), file("*.${species}.${expName}.meta_for_quant.txt"), file("*.${species}.${expName}.meta_for_tertiary.txt") into CONFSDRF_BY_EXP_SPECIES
+        set val(expName), val(species), file("*.${species}.${expName}.conf"), file("*.${species}.${expName}.meta_for_quant.txt"), file("*.${species}.${expName}.meta_for_tertiary.txt") into CONF_ANALYSIS_META_BY_EXP_SPECIES
 
     """
     # Cells file will be empty (from reminder: true above) for some experiments
     cells_options=
     cells_filesize=\$(stat --printf="%s" \$(readlink ${cellsFile}))
     if [ \$cells_filesize -gt 0 ]; then
-        cells_options="--cells=$cellsFile --cell_meta_fields="$params.cellAnalysisFields""
+        cells_options="--cells=$cellsFile"
     fi
-
+    
+    if [ -n "$params.cellAnalysisFields" ]; then
+        cells_options="\$cells_options --cell_meta_fields=\\"$params.cellAnalysisFields\\""
+    fi
+    
     mkdir -p tmp
-    sdrfToNfConf.R \
+    eval "sdrfToNfConf.R \
         --sdrf=\$(readlink $sdrfFile) \
         --idf=$idfFile \$cells_options \
         --name=$expName \
         --verbose \
-        --out_conf \$(pwd)
+        --out_conf \$(pwd)"
     """
 }
+// The transpose step below gives us the protocol-wise configs, converting:
+// [ 'E-MTAB-1234', 'rabbit', [ '10xv2.rabbit.E-MTAB-1234.conf', '10xv3.rabbit.E-MTAB-1234.conf' ], [ '10xv2.rabbit.E-MTAB-1234.meta_for_quant.txt', '10xv3.rabbit.E-MTAB-1234.meta_for_quant.txt' ], ['10xv2.rabbit.E-MTAB-1234.meta_for_tertiary.txt', '10xv3.rabbit.E-MTAB-1234.meta_for_tertiary.txt' ] ]
+// to:
+//
+// [ 'E-MTAB-1234', 'rabbit', '10xv2', '10xv2.rabbit.E-MTAB-1234.conf', '10xv2.rabbit.E-MTAB-1234.meta_for_quant.txt', '10xv2.rabbit.E-MTAB-1234.meta_for_tertiary.txt' ]
+// [ 'E-MTAB-1234', 'rabbit', '10xv3', '10xv3.rabbit.E-MTAB-1234.conf', '10xv3.rabbit.E-MTAB-1234.meta_for_quant.txt', '10xv3.rabbit.E-MTAB-1234.meta_for_tertiary.txt' ]
+//
+// Protocol is first part of '.' - separated file name from sdrfToNfConf, so we
+// can use simpleName to extract it
+
+CONF_ANALYSIS_META_BY_EXP_SPECIES
+    .transpose()
+    .map { r -> tuple(r[0], r[1], r[2].simpleName, r[2], r[3], r[4]) }
+    .set{ CONF_ANALYSIS_META_BY_EXP_SPECIES_PROTOCOL }
+
+
+///////////////////////////////////////////////////////////////////////////////
+// In this section we use the above-generated config to learn about the
+// experiments. What combinations of experiment, species and protocol do we
+// have? Which ones are droplet? Have controlled access expeirments been
+// properly provided for?
+///////////////////////////////////////////////////////////////////////////////
 
 // Check for controlled access status. This will exclude an experiment unless
 // all requirements on user, directory etc are in place for a controlled access
-// quantification
+// quantification. This process is intentionally not parallelised with others,
+// to act as a bottle neck and cause the experiment to cease processing unless
+// this check passes.
+//
+// We also create compact tags to be used here so we don't always have to pass
+// around exp/species/protocol
 
 process check_controlled_access{
     
@@ -297,10 +258,12 @@ process check_controlled_access{
     errorStrategy 'ignore'
 
     input:
-        set val(expName), val(species), file(referenceFasta), file(referenceGtf), file(contIndex), file(confFile) from CONF_REF_BY_EXP_SPECIES
+        set val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary) from CONF_ANALYSIS_META_BY_EXP_SPECIES_PROTOCOL
 
     output:
-        set val(expName), val(species), file(referenceFasta), file(referenceGtf), file(contIndex), file(confFile) into CONF_REF_BY_EXP_SPECIES_CA_CHECKED
+        set val("${expName}-${species}-${protocol}"), val(expName), val(species), val(protocol) into ESP_TAGS
+        set val("${expName}-${species}-${protocol}"), file(confFile) into CONF_BY_EXP_SPECIES_PROTOCOL
+        set val("${expName}-${species}-${protocol}"), file(metaForQuant), file(metaForTertiary) into ANALYSIS_META_BY_EXP_SPECIES_PROTOCOL
 
 
     """
@@ -308,35 +271,65 @@ process check_controlled_access{
     """
 }
 
-CONF_REF_BY_EXP_SPECIES_CA_CHECKED.into{
-    CONF_REF_BY_EXP_SPECIES_FOR_QUANT
-    CONF_REF_BY_EXP_SPECIES_FOR_TERTIARY
-    CONF_REF_BY_EXP_SPECIES_FOR_BUNDLE
+ANALYSIS_META_BY_EXP_SPECIES_PROTOCOL.into{
+    ANALYSIS_META_FOR_CHANGEDCHECK
+    ANALYSIS_META_FOR_QUANT
 }
 
-// Protocol is first part of '.' - separated file name from sdrfToNfConf, so we
-// can use simpleName to extract it
+CONF_BY_EXP_SPECIES_PROTOCOL.into{
+    CONF_BY_EXP_SPECIES_PROTOCOL_FOR_ES_CONFIG
+    CONF_BY_EXP_SPECIES_PROTOCOL_FOR_EXTEND
+}
 
-CONF_REF_BY_EXP_SPECIES_FOR_QUANT
-    .transpose()
-    .map { r -> tuple(r[0], r[1], r[5].simpleName, r[2], r[3], r[4], r[5]) }
-    .set{ CONF_REF_BY_EXP_SPECIES_PROTOCOL }
+// Experiment/ species/ protocol tags
 
-CONFSDRF_BY_EXP_SPECIES
-    .transpose()
-    .map { r -> tuple(r[0], r[1], r[2].simpleName, r[2], r[3]) }
-    .set{ CONFSDRF_BY_EXP_SPECIES_PROTOCOL }
+ESP_TAGS.into{
+    ESP_TAGS_FOR_AGG_ROUTING
+    ESP_TAGS_FOR_ES_CONFIG
+    ESP_TAGS_FOR_PROT_LIST
+    ESP_TAGS_FOR_CHANGEDCHECK
+    ESP_TAGS_FOR_EXTEND
+    ESP_TAGS_FOR_MARKING
+    ESP_TAGS_FOR_REFERENCE
+    ESP_TAGS_FOR_SYNCH_REFS
+    ESP_TAGS_FOR_QUANT_CHECK
+    ESP_TAGS_FOR_REUSE_QUANT
+    ESP_TAGS_FOR_QUANT
+    ESP_TAGS_FOR_AGGR
+    ESP_TAGS_FOR_IS_DROPLET
+}
 
+// Make comma-separated list of the protocols for each exp/species combo
+
+ESP_TAGS_FOR_PROT_LIST
+    .map{r -> tuple(r[1], r[2], r[3])}
+    .groupTuple( by: [0,1] )
+    .map{r -> tuple((r[0] + '-' +  r[1]).toString(), r[2].join(","))}
+    .set{
+        PROTOCOLS_BY_EXP_SPECIES
+    }
+
+// Take the first config file in a species/ experiment combo to use in
+// processes not dependent on protocol
+
+ESP_TAGS_FOR_ES_CONFIG
+    .join(CONF_BY_EXP_SPECIES_PROTOCOL_FOR_ES_CONFIG)
+    .groupTuple( by: [1,2] )
+    .map{ r -> tuple( (r[1] + '-' + r[2]).toString(), r[4][0] ) }
+    .into{
+       CONF_BY_EXP_SPECIES_FOR_CELLMETA
+       CONF_BY_EXP_SPECIES_FOR_BUNDLE 
+    }
+
+// Extend config for protocol-wise info
 
 process extend_config_for_protocol{
 
     input:
-        set val(expName), val(species), val(protocol),  file(referenceFasta), file(referenceGtf), file(contIndex), file(confFile), file(metaForQuant), file(metaForTertiary) from CONF_REF_BY_EXP_SPECIES_PROTOCOL.join(CONFSDRF_BY_EXP_SPECIES_PROTOCOL, by: [0,1,2])
+        set val(espTag), val(expName), val(species), val(protocol), file(confFile) from ESP_TAGS_FOR_EXTEND.join(CONF_BY_EXP_SPECIES_PROTOCOL_FOR_EXTEND)
 
     output:
-        set val("${expName}-${species}-${protocol}"), val(expName), val(species), val(protocol) into TAGS 
-        set val("${expName}-${species}-${protocol}"), file("${expName}.${species}.${protocol}.conf"), file(metaForQuant), file(metaForTertiary) into TAGGED_CONF 
-        set val("${expName}-${species}-${protocol}"), file(referenceFasta), file(referenceGtf), file(contIndex) into TAGGED_REFERENCES
+        set val(espTag), file("${expName}.${species}.${protocol}.conf") into EXTENDED_CONF
     
     """
     # Add in protocol-specific parameters by 'include'ing external configs
@@ -356,22 +349,11 @@ process extend_config_for_protocol{
     """
 }
 
-
-TAGS.into{
-    TAGS_FOR_MARKING
-    TAGS_FOR_REF
-    TAGS_FOR_CHANGEDCHECK
-    TAGS_FOR_QUANT
-    TAGS_FOR_AGGR
-    TAGS_FOR_IS_DROPLET
-    TAGS_FOR_TERTIARY
-    TAGS_FOR_BUNDLE
-}
-
-TAGGED_CONF.into{
-    CONF_FOR_CHANGEDCHECK
-    CONF_FOR_QUANT
-    PRE_CONF_FOR_TERTIARY
+EXTENDED_CONF.into{
+    EXTENDED_CONF_FOR_CHANGED_CHECK
+    EXTENDED_CONF_FOR_REF
+    EXTENDED_CONF_FOR_QUANT
+    EXTENDED_CONF_FOR_CELL_TO_LIB
 }
 
 // Mark droplet protocols
@@ -379,10 +361,10 @@ TAGGED_CONF.into{
 process mark_droplet {
    
     input:
-        set val(tag), val(expName), val(species), val(protocol) from TAGS_FOR_MARKING
+        set val(espTag), val(expName), val(species), val(protocol) from ESP_TAGS_FOR_MARKING
 
     output:
-        set val(tag), stdout into IS_DROPLET
+        set val(espTag), stdout into IS_DROPLET
     
     script: 
 
@@ -403,9 +385,10 @@ process mark_droplet {
 IS_DROPLET.into{
     IS_DROPLET_PROT
     IS_DROPLET_FOR_EXP_SPECIES_TEST
+    IS_DROPLET_FOR_REUSE_QUANT
 }
 
-TAGS_FOR_IS_DROPLET
+ESP_TAGS_FOR_IS_DROPLET
     .join(IS_DROPLET_FOR_EXP_SPECIES_TEST)
     .map{ r -> tuple ( r[1], r[2], r[4]) }
     .unique()
@@ -421,7 +404,7 @@ process check_droplet_status {
         set val(expName), val(species), val(isDroplets) from EXP_SPECIES_IS_DROPLETS
 
     output:
-        set val(expName), val(species), stdout into IS_DROPLET_EXP_SPECIES
+        set val("${expName}-${species}"), stdout into IS_DROPLET_EXP_SPECIES
 
     script: 
 
@@ -442,96 +425,317 @@ IS_DROPLET_EXP_SPECIES.into{
     IS_DROPLET_EXP_SPECIES_FOR_TERTIARY
 }
 
-// Where analysis is already present, check that the config has actually changed
-// in a way that impacts on analysis. This is distinct from
+///////////////////////////////////////////////////////////////////////////////
+// Processes and transformations in this channel will decide how data are
+// re-used or re-analysed
+///////////////////////////////////////////////////////////////////////////////
+
+// Where analysis is already present, check that the config has actually
+// changed in a way that impacts on analysis. This is distinct from
 // checkExperimentStatus(), which just flags where the source SDRF has a newer
-// timestamp than the analysis.
+// timestamp than the analysis. We could have multiple protocol-wise files, but
+// the status is returned at the experiment/ species level (note the use of
+// groupTuple() below). Quantification is the only stage peformed at the
+// protocol-wise level, and if one protocol of a set is being re-quantified we
+// should probbly do the others for consistency in reference usage (we normally
+// use the most up-to-date reference when quantifying). We could do reference
+// checks to prevent unnecessary re-computation of protocols in multi-protocol
+// experiments, but that logic seems unnecessary complication to the logic
+// right now.
+
+ESP_TAGS_FOR_CHANGEDCHECK
+    .join(EXTENDED_CONF_FOR_CHANGED_CHECK)
+    .join(ANALYSIS_META_FOR_CHANGEDCHECK)
+    .groupTuple( by: [1,2])
+    .set{
+        CHANGED_CHECK_INPUTS
+    }
 
 process check_experiment_changed{
 
+    publishDir "$SCXA_CONF/study", mode: 'copy', overwrite: true
+    
     input:
-        set val(tag), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary) from TAGS_FOR_CHANGEDCHECK.join(CONF_FOR_CHANGEDCHECK)
+        set val(espTags), val(expName), val(species), val(protocols), file('confFile/*'), file('metaForQuant/*'), file('metaForTertiary/*') from CHANGED_CHECK_INPUTS
 
     output:
-        set val(tag), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), stdout into COMPILED_DERIVED_CONFIG_WITH_STATUS
+        set val(expName), val(species), val(espTags), stdout into CHANGE_STATUS
+        set file("*.conf"), file("*.meta_for_quant.txt"), file("*.meta_for_tertiary.txt") optional true
         
-
     """
-    checkExperimentChanges.sh $expName $species $confFile $metaForQuant $metaForTertiary
+    expStatus=\$(checkExperimentChanges.sh $expName $species confFile metaForQuant metaForTertiary $skipQuantification $skipAggregation $skipTertiary $overwrite)
+
+    if [ "\$expStatus" == 'changed' ]; then
+        cp -P confFile/* metaForTertiary/* metaForQuant/* .
+    elif [ "\$expStatus" == 'meta_changed' ]; then
+        cp -P metaForTertiary/* .
+    fi
+    echo -n "\$expStatus"
     """
 }
+
+// For no changes for any of the protocol-wise secions of an experiment, we're
+// re-reporting the bundle lines, so no further action required
 
 NEW_OR_CHANGED_EXPERIMENTS = Channel.create()
 NOT_CHANGED_EXPERIMENTS = Channel.create()
 
-COMPILED_DERIVED_CONFIG_WITH_STATUS.choice( NEW_OR_CHANGED_EXPERIMENTS, NOT_CHANGED_EXPERIMENTS ) {a -> 
-    a[7] == 'unchanged' ? 1 : 0
+CHANGE_STATUS.choice( NEW_OR_CHANGED_EXPERIMENTS, NOT_CHANGED_EXPERIMENTS ){a ->
+    a[3] == 'unchanged' ? 1 : 0
 }
 
-CHANGED_FOR_QUANT = Channel.create()
-CHANGED_FOR_TERTIARY_ONLY = Channel.create()
-
-NEW_OR_CHANGED_EXPERIMENTS.choice( CHANGED_FOR_QUANT, CHANGED_FOR_TERTIARY_ONLY ) {a -> 
-    a[7] == 'meta_changed' ? 1 : 0
-}
-
-// Generate bundle lines for the things updated but not actually changed for
-// analysis
-
-process get_not_changed_bundles {
-
-    input:
-        set val(expName), val(species) from NOT_CHANGED_EXPERIMENTS.map{r -> tuple(r[1], r[2])}
-
-    output:
-         file('bundleLines.txt') into NOT_CHANGED_BUNDLES
-
-    """
-        # Update the manifest time stamps to prevent re-config next time
-        touch -m $SCXA_RESULTS/$expName/$species/bundle/MANIFEST
-
-        echo -e "$expName\\t$species\\t$SCXA_RESULTS/$expName/$species/bundle" > bundleLines.txt
-    """
-}
+NOT_CHANGED_EXPERIMENTS
+    .map{r -> tuple(r[0], r[1])}
+    .set{
+        NOT_CHANGED_EXPERIMENTS_FOR_BUNDLES
+    }
 
 // For experiments we know are due for re-analysis, remove pre-existing
 // results (where appropriate). This is also the time to publish the config
 // files, overwriting any already in place.
 
-//[E-MTAB-6077-danio_rerio-smart-seq, E-MTAB-6077, danio_rerio, smart-seq, changed]
-
 process reset_experiment{
     
-    publishDir "$SCXA_CONF/study", mode: 'copy', overwrite: true
-
     input:
-        set val(tag), val(expName), val(species), val(protocol), file("in/*"), file("in/*"), file("in/*"), val(expStatus) from CHANGED_FOR_QUANT
+        set val(expName), val(species), val(espTags), val(expStatus) from NEW_OR_CHANGED_EXPERIMENTS
 
     output:
-        set val(tag), file("*.conf"), file("*.meta_for_quant.txt"), file("*.meta_for_tertiary.txt") into NEW_OR_RESET_EXPERIMENTS
+        set val(espTags), val(expStatus) into NEW_OR_RESET_EXPERIMENTS
         
     """
         # Only remove downstream results where we're not re-using them
-        reset_stages='bundle'
-        if [ "$skipQuantification" == 'no' ]; then
-            reset_stages="quantification aggregation scanpy \$reset_stages"
-        elif [ "$skipAggregation" = 'no' ]; then 
-            reset_stages="aggregation scanpy \$reset_stages"
-        elif [ "$skipTertiary" = 'no' ]; then 
-            reset_stages="scanpy \$reset_stages"
+
+        if [ "$expStatus" = 'changed_for_quantification' ];then
+            reset_stages="quantification reference aggregation scanpy bundle"
+        elif [ "$expStatus" = 'changed_for_aggregation' ];then
+            reset_stages="aggregation scanpy bundle"
+        elif [ "$expStatus" = 'changed_for_tertiary' ];then
+            reset_stages="scanpy bundle"
+        else
+            reset_stages="bundle"
         fi
 
         for stage in \$reset_stages; do
             rm -rf $SCXA_RESULTS/$expName/$species/\$stage
         done
-
-        # Now we've removed the results, link the results for publishing
-
-        cp -P in/*.meta_for_quant.txt in/*conf in/*.meta_for_tertiary.txt .
     """
 }
 
-// Prepare a reference depending on spikes
+NEW_OR_RESET_EXPERIMENTS
+    .transpose()
+    .into{
+        EXPERIMENTS_FOR_REF
+        EXPERIMENTS_FOR_ANALYSIS
+    }
+
+// We've done the right resets, good to go with any new analysis. Route
+// experiments different ways depending on in what way a change has been
+// observed
+
+TO_RETERTIARY = Channel.create()
+TO_REAGGREGATE = Channel.create()
+TO_QUANTIFY = Channel.create()
+
+NOT_CHANGED_FOR_QUANT = Channel.create()
+NOT_CHANGED_FOR_AGGREGATION = Channel.create()
+NOT_CHANGED_FOR_TERTIARY = Channel.create()
+
+// Re-quantify a whole experiment if any of its protocol-wise components
+// require it
+
+EXPERIMENTS_FOR_ANALYSIS.join(ESP_TAGS_FOR_QUANT_CHECK).groupTuple( by: [2,3]).choice( TO_QUANTIFY, NOT_CHANGED_FOR_QUANT ) {a -> 
+    a[1].contains('changed_for_quantification') ? 0 : 1
+}
+
+TO_QUANTIFY
+    .map{ r -> tuple( r[0] ) }
+    .into{
+        TO_QUANTIFY_FOR_QUANT
+        TO_QUANTIFY_FOR_REFERENCE
+    }
+
+NOT_CHANGED_FOR_QUANT
+    .transpose()
+    .map{ r -> tuple( r[0], r[1]) }
+    .into{
+        NOT_CHANGED_FOR_QUANT_FOR_REFERENCES
+        NOT_CHANGED_FOR_QUANT_FOR_QUANT
+        NOT_CHANGED_FOR_QUANT_FOR_REUSE_QUANT
+        NOT_CHANGED_FOR_QUANT_FOR_ROUTING
+    }
+
+// Quantification-subseqent steps have protocols merged
+
+NOT_CHANGED_FOR_QUANT_FOR_ROUTING.choice( TO_REAGGREGATE, NOT_CHANGED_FOR_AGGREGATION ) {a -> 
+    a[1] == 'changed_for_aggregation' ? 0 : 1
+}
+
+NOT_CHANGED_FOR_AGGREGATION                                 // esp_tag, expStatus
+    .join( ESP_TAGS_FOR_AGG_ROUTING )                       // esp_tag, expStatus, expName, species, protocol
+    .map{ r -> tuple( (r[2] + '-' + r[3]).toString(), r[1] ) }           // es_tag, expStatus
+    .into{
+        NOT_CHANGED_FOR_AGGREGATION_FOR_ROUTING
+        NOT_CHANGED_FOR_AGGREGATION_FOR_REUSE_AGG
+    }
+
+NOT_CHANGED_FOR_AGGREGATION_FOR_ROUTING.choice( TO_RETERTIARY, NOT_CHANGED_FOR_TERTIARY ) {a -> 
+    a[1] == 'changed_for_tertiary' ? 0 : 1
+}
+
+NOT_CHANGED_FOR_TERTIARY
+    .map{r -> tuple(r[0])}
+    .into{
+        NOT_CHANGED_FOR_TERTIARY_FOR_REUSE_TERTIARY
+        TO_REBUNDLE    
+    }
+
+///////////////////////////////////////////////////////////////////////////////
+// Processes to derive results to re-use. These will be combined with novel
+// results from other channels as appropriate
+///////////////////////////////////////////////////////////////////////////////
+
+// This process re-uses previously generated quantifcation results
+
+process reuse_quantifications {
+    
+    executor 'local'
+
+    input:
+        set val(espTag), val(expStatus), val(expName), val(species), val(protocol), val(isDroplet) from NOT_CHANGED_FOR_QUANT_FOR_QUANT.join(ESP_TAGS_FOR_REUSE_QUANT).join(IS_DROPLET_FOR_REUSE_QUANT)
+
+    output:
+        set val(espTag), file("results/*") into REUSED_QUANT_RESULTS
+        set val("${expName}-${species}"), file("*.fa.gz"), file("*.gtf.gz"), stdout into REUSED_REFERENCES
+        set val(espTag), file('transcript_to_gene.txt') into REUSED_TRANSCRIPT_TO_GENE
+
+    """
+    retrieveStoredFiles.sh $expName $species reference "*.fa.gz *.gtf.gz transcript_to_gene.txt" 
+    mkdir -p results
+
+    if [ $isDroplet == 'True' ]; then
+        retrieveStoredFiles.sh $expName $species quantification "$protocol/alevin" results/alevin 
+    else
+        retrieveStoredFiles.sh $expName $species quantification "$protocol/kallisto" results/kallisto
+    fi
+    """
+}
+
+// Use existing aggregations if specified. Note that the aggregations can only
+// be reused if the quantifications are reused to maintain consistency, so the
+// QUANT_RESULTS channel cannot be allowed to go to reuse_aggregation
+
+process reuse_aggregation {
+
+    executor 'local'
+    
+    input:
+        set val(esTag), val(expStatus), val(expName), val(species) from NOT_CHANGED_FOR_AGGREGATION_FOR_REUSE_AGG.join(ES_TAGS_FOR_REUSE_AGG)
+
+    output:
+        set val(esTag), file("matrices/counts_mtx.zip") into REUSED_COUNT_MATRICES
+        set val(esTag), file("matrices/tpm_mtx.zip") optional true into REUSED_TPM_MATRICES
+        set val(esTag), file("matrices/stats.tsv") optional true into REUSED_KALLISTO_STATS
+        set val(esTag), file("${expName}.${species}.condensed-sdrf.tsv") into REUSED_CONDENSED  
+        set val(esTag), file("${expName}-${species}.metadata.matched.tsv") into REUSED_MATCHED_META
+
+    """
+        retrieveStoredFiles.sh $expName $species aggregation matrices
+        retrieveStoredFiles.sh $expName $species metadata "${expName}-${species}.metadata.matched.tsv ${expName}.${species}.condensed-sdrf.tsv"
+    """
+}
+
+REUSED_COUNT_MATRICES.into{
+    REUSED_COUNT_MATRICES_FOR_TERTIARY
+    REUSED_COUNT_MATRICES_FOR_BUNDLING
+}
+
+// Derive existing tertiary results for cases where we're just re-bundling
+
+process reuse_tertiary {
+
+    executor 'local'
+    
+    input:
+        set val(esTag), val(expStatus), val(expName), val(species) from NOT_CHANGED_FOR_TERTIARY_FOR_REUSE_TERTIARY.join(ES_TAGS_FOR_REUSE_TERTIARY)
+    
+    output:
+        set val(esTag), file("matrices/raw_filtered.zip"), file("matrices/filtered_normalised.zip"), file("clusters_for_bundle.txt"), file("umap"), file("tsne"), file("markers"), file('clustering_software_versions.txt') into REUSED_TERTIARY_RESULTS
+
+    """
+        retrieveStoredFiles.sh $expName $species scanpy "matrices clusters_for_bundle.txt umap tsne markers clustering_software_versions.txt"
+    """
+}
+
+////////////////////////////////////////////////////////////////
+// Processes to derive new results
+////////////////////////////////////////////////////////////////
+
+// Symlink to correct reference file, re-using the reference from last
+// quantification where appropriate
+
+process add_reference {
+
+    conda 'pyyaml' 
+    
+    cache 'deep'
+    
+    errorStrategy { task.attempt<=3 ? 'retry' : 'finish' }
+        
+    publishDir "$SCXA_RESULTS/$expName/$species/reference", mode: 'copy', overwrite: true
+
+    input:
+        set val(espTag), val(expName), val(species), val(protocol) from TO_QUANTIFY_FOR_REFERENCE.join(ESP_TAGS_FOR_REFERENCE)
+
+    output:
+        set val(espTag), file("*.fa.gz"), file("*.gtf.gz"), stdout into NEW_REFERENCES_FOR_QUANT
+        set val("${expName}-${species}"), file("*.fa.gz"), file("*.gtf.gz"), stdout into NEW_REFERENCES_FOR_DOWNSTREAM
+
+    """
+    # Use references from the ISL setup
+    if [ -n "\$ISL_GENOMES" ] && [ "\$IRAP_CONFIG_DIR" != '' ] && [ "\$IRAP_DATA" != '' ]; then
+        irap_species_conf=$IRAP_CONFIG_DIR/${species}.conf
+        if [ ${params.islReferenceType} = 'newest' ]; then
+            gtf_pattern=\$(basename \$(cat \$ISL_GENOMES | grep $species | awk '{print \$6}') | sed 's/RELNO/\\*/')
+            cdna_pattern=\$(basename \$(cat \$ISL_GENOMES | grep $species | awk '{print \$5}') | sed 's/RELNO/\\*/' | sed 's/.fa.gz/.\\*.fa.gz/') 
+
+            cdna_gtf=\$(ls \$IRAP_DATA/reference/${species}/\$gtf_pattern | sort -rV | head -n 1)
+            cdna_fasta=\$(ls \$IRAP_DATA/reference/${species}/\$cdna_pattern | sort -rV | head -n 1)
+        else
+            cdna_fasta=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf cdna_file)   
+            cdna_gtf=$IRAP_DATA/reference/$species/\$(parseIslConfig.sh \$irap_species_conf gtf_file)   
+        fi
+        if [ ! -e "\$cdna_fasta" ]; then
+            echo "Fasta file \$cdna_fasta does not exist" 1>&2
+            exit 1
+        elif [ ! -e "\$cdna_gtf" ]; then
+            echo "GTF file \$cdna_gtf does not exist" 1>&2
+            exit 1
+        fi
+        contamination_index=\$(parseIslConfig.sh \$irap_species_conf cont_index)  
+    else
+        echo "All of environment variables ISL_GENOMES, IRAP_CONFIG_DIR AND IRAP_DATA must be set" 1>&2
+        exit 1
+    fi
+   
+    echo -n "\$contamination_index"
+    
+    ln -s \$cdna_fasta
+    ln -s \$cdna_gtf
+    """
+}
+
+// References used in tertiary analysis and bundling are a combination of the
+// reused and new references depending on individual experiment statuses
+
+NEW_REFERENCES_FOR_DOWNSTREAM.unique()
+    .concat(REUSED_REFERENCES.unique())
+    .into{
+        REFERENCES_FOR_TERTIARY
+        REFERENCES_FOR_BUNDLING
+    }
+
+// Prepare a reference depending on spikes for quantification. Only needed for
+// quantification or re-aggregation
 
 process prepare_reference {
 
@@ -542,33 +746,33 @@ process prepare_reference {
     errorStrategy { task.attempt<=3 ? 'retry' : 'finish' }
 
     input:
-        set val(tag), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex) from NEW_OR_RESET_EXPERIMENTS.join(TAGGED_REFERENCES)
+        set val(espTag), file(confFile), file(referenceFasta), file(referenceGtf), val(contaminationIndex) from EXTENDED_CONF_FOR_REF.join(NEW_REFERENCES_FOR_QUANT)
     
     output:
-        set val(tag), file("out/*.fa.gz"), file("out/*.gtf.gz"), val(contaminationIndex) into PREPARED_REFERENCES
+        set val(espTag), file("reference.fa.gz"), file("reference.gtf.gz"), val(contaminationIndex) into PREPARED_REFERENCES
 
     """
-    mkdir -p out
     spikes=\$(parseNfConfig.py --paramFile $confFile --paramKeys params,spikes)
     if [ \$spikes != 'None' ]; then
         spikes_conf="$SCXA_PRE_CONF/reference/\${spikes}.conf"
         spikes_fasta=$SCXA_DATA/reference/\$(parseNfConfig.py --paramFile \$spikes_conf --paramKeys params,reference,spikes,cdna)
         spikes_gtf=$SCXA_DATA/reference/\$(parseNfConfig.py --paramFile \$spikes_conf --paramKeys params,reference,spikes,gtf)
         
-        cat $referenceFasta \$spikes_fasta > out/reference.fa.gz
-        cat $referenceGtf \$spikes_gtf > out/reference.gtf.gz
+        cat $referenceFasta \$spikes_fasta > reference.fa.gz
+        cat $referenceGtf \$spikes_gtf > reference.gtf.gz
     else
-        cp -P $referenceGtf out/reference.gtf.gz
-        cp -P $referenceFasta out/reference.fa.gz
+        cp -P $referenceGtf reference.gtf.gz
+        cp -P $referenceFasta reference.fa.gz
     fi
     """
 }
-
 
 // Synchronise the GTF and the FASTA 
 
 process synchronize_ref_files {
 
+    publishDir "$SCXA_RESULTS/$expName/$species/reference", mode: 'copy', overwrite: true, pattern: 'transcript_to_gene.txt'
+    
     conda "${baseDir}/envs/atlas-gene-annotation-manipulation.yml"
     
     cache 'deep'
@@ -579,11 +783,11 @@ process synchronize_ref_files {
     maxRetries 3
         
     input:
-        set val(tag), file(referenceFasta), file(referenceGtf), val(contaminationIndex) from PREPARED_REFERENCES
+        set val(espTag), file(referenceFasta), file(referenceGtf), val(contaminationIndex), val(expName), val(species), val(protocol) from PREPARED_REFERENCES.join(ESP_TAGS_FOR_SYNCH_REFS)
 
     output:
-        set val(tag), file('cleanedCdna.fa.gz'), file(referenceGtf), val(contaminationIndex) into CLEANED_REFERENCES
-        set val(tag), file('transcript_to_gene.txt') into TRANSCRIPT_TO_GENE
+        set val(espTag), file('cleanedCdna.fa.gz'), file(referenceGtf), val(contaminationIndex) into CLEANED_REFERENCES
+        set val(espTag), file('transcript_to_gene.txt') into TRANSCRIPT_TO_GENE
 
     """
     gtf2featureAnnotation.R --gtf-file ${referenceGtf} --no-header --version-transcripts --filter-cdnas ${referenceFasta} \
@@ -592,10 +796,12 @@ process synchronize_ref_files {
     """
 }
 
-TRANSCRIPT_TO_GENE.into{
-    TRANSCRIPT_TO_GENE_QUANT
-    TRANSCRIPT_TO_GENE_AGGR
-}
+TRANSCRIPT_TO_GENE
+    .concat(REUSED_TRANSCRIPT_TO_GENE)
+    .into{
+        TRANSCRIPT_TO_GENE_QUANT
+        TRANSCRIPT_TO_GENE_AGGR
+    }
 
 // Make a configuration for the Fastq provider, and make initial assessment
 // of the available ENA download methods. This establishes a mock
@@ -622,69 +828,18 @@ INIT_DONE
         INIT_DONE_DROPLET
     }
 
-// Compile the info we need for quantification
+// Compile the info we need for fresh quantification
 
-IS_DROPLET_PROT
-    .join(TAGS_FOR_QUANT)
-    .join(CONF_FOR_QUANT)
+TO_QUANTIFY_FOR_QUANT
+    .join(IS_DROPLET_PROT)
+    .join(ESP_TAGS_FOR_QUANT)
+    .join(EXTENDED_CONF_FOR_QUANT)
+    .join(ANALYSIS_META_FOR_QUANT)
     .join(CLEANED_REFERENCES)
     .join(TRANSCRIPT_TO_GENE_QUANT)
     .set{
-        PRE_QUANT_INPUTS
+        QUANT_INPUTS
     }
-
-
-// If we just want to run tertiary using our published quantification results
-// from previous runs, we can do that
-
-QUANT_INPUTS = Channel.create()
-QUANT_SPOOF_INPUTS = Channel.create()
-
-// The contents of CHANGED_FOR_TERTIARY_ONLY is experiments with changes that
-// require tertiary re-analysis but not quantification- e.g. changes to cell
-// type information. But even the content of PRE-QUANT inputs (normally going
-// through quantification) will be directed to skip quantification if the flag
-// is specified.
-
-CHANGED_FOR_TERTIARY_ONLY.map{  r -> tuple( r[0], r[1], r[2], r[3] ) }
-    .set{PRE_QUANT_SPOOF_INPUTS}
-
-if ( skipQuantification == 'yes'){
-    PRE_QUANT_INPUTS
-        .map{ r -> tuple( r[0], r[2], r[3], r[4] ) }
-        .concat(PRE_QUANT_SPOOF_INPUTS)        
-        .set{QUANT_SPOOF_INPUTS}
-    
-    QUANT_INPUTS = Channel.empty()
-}else{
-    PRE_QUANT_SPOOF_INPUTS
-        .set{QUANT_SPOOF_INPUTS}
-    
-    PRE_QUANT_INPUTS
-        .set{ QUANT_INPUTS }
-}
-
-// This process re-uses previously generated quantifcation results
-
-process spoof_quantify {
-    
-    executor 'local'
-
-    input:
-        set val(tag), val(expName), val(species), val(protocol) from QUANT_SPOOF_INPUTS
-
-    output:
-        set val(tag), file("results/*") into SPOOFED_QUANT_RESULTS
-
-    """
-        mkdir -p results
-        for PROG in alevin kallisto; do
-            if [ -e $SCXA_RESULTS/$expName/$species/quantification/$protocol/\$PROG ]; then
-                ln -s $SCXA_RESULTS/$expName/$species/quantification/$protocol/\$PROG results/\$PROG
-            fi
-        done
-    """
-}
 
 // Separate droplet and smart-type experiments
 
@@ -712,12 +867,12 @@ process smart_quantify {
     maxRetries 10
     
     input:
-        set val(tag), val(isDroplet), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex), file(transcriptToGene) from SMART_INPUTS
+        set val(espTag), val(isDroplet), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex), file(transcriptToGene) from SMART_INPUTS
         val flag from INIT_DONE_SMART
 
     output:
-        set val(tag), file ("kallisto") into SMART_KALLISTO_DIRS 
-        set val(tag), file ("qc") into SMART_QUANT_QC
+        set val(espTag), file ("kallisto") into SMART_KALLISTO_DIRS 
+        set val(espTag), file ("qc") into SMART_QUANT_QC
         file('quantification.log')    
 
     """
@@ -741,11 +896,11 @@ process droplet_quantify {
     errorStrategy { task.attempt<=5 ? 'retry' : 'ignore' }
 
     input:
-        set val(tag), val(isDroplet), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex), file(transcriptToGene) from DROPLET_INPUTS
+        set val(espTag), val(isDroplet), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex), file(transcriptToGene) from DROPLET_INPUTS
         val flag from INIT_DONE_DROPLET
 
     output:
-        set val(tag), file("alevin") into ALEVIN_DROPLET_DIRS
+        set val(espTag), file("alevin") into ALEVIN_DROPLET_DIRS
         file('quantification.log')    
 
     """
@@ -758,110 +913,83 @@ process droplet_quantify {
 SMART_KALLISTO_DIRS
     .concat(ALEVIN_DROPLET_DIRS)
     .set { 
-        PRE_QUANT_RESULTS 
+        NEW_QUANT_RESULTS 
     }
 
-SPOOFED_QUANT_RESULTS
-    .concat(PRE_QUANT_RESULTS)
-    .set{
-        QUANT_RESULTS
-    }
+// Aggregation just needs the quantification results and the transcript/ gene
+// mappings. Input is the combination of new quantifications, and reused
+// existing quantifications specified for reaggregation.
 
-// Aggregation just needs the quantifation results and the transcript/ gene
-// mappings
-
-TAGS_FOR_AGGR
-    .join(QUANT_RESULTS)
+ESP_TAGS_FOR_AGGR
+    .join(NEW_QUANT_RESULTS.concat(TO_REAGGREGATE.join(REUSED_QUANT_RESULTS)))
     .join(TRANSCRIPT_TO_GENE_AGGR)
     .groupTuple( by: [1,2] )
+    .map{ r -> tuple( r[1], r[2], r[3], r[5], r[6] ) }
     .set{ GROUPED_QUANTIFICATION_RESULTS }
 
-// Use existing aggregations if specified
-
-if (skipAggregation == 'yes' ){
-
-    process spoof_aggregate {
+process aggregate {
     
-        executor 'local'
-        
-        input:
-            set val(tags), val(expName), val(species), file('quant_results/??/protocol'), file('quant_results/??/*'), file('quant_results/??/*') from GROUPED_QUANTIFICATION_RESULTS   
-
-        output:
-            set val(expName), val(species), file("matrices/counts_mtx.zip") into COUNT_MATRICES
-            set val(expName), val(species), file("matrices/tpm_mtx.zip") optional true into TPM_MATRICES
-            set val(expName), val(species), file("matrices/stats.tsv") optional true into KALLISTO_STATS
+    conda "${baseDir}/envs/nextflow.yml"
     
-        """
-            ln -s $SCXA_RESULTS/$expName/$species/aggregation/matrices 
-        """
-    }
+    maxForks 6
 
-}else{
+    publishDir "$SCXA_RESULTS/$expName/$species/aggregation", mode: 'copy', overwrite: true
+    
+    memory { 4.GB * task.attempt }
+    errorStrategy { task.exitStatus == 130 || task.exitStatus == 137 || task.attempt < 3 ? 'retry' : 'finish' }
+    maxRetries 20
+    
+    input:
+        set val(expName), val(species), file('quant_results/??/protocol'), file('quant_results/??/*'), file('quant_results/??/*') from GROUPED_QUANTIFICATION_RESULTS   
 
-    process aggregate {
-        
-        conda "${baseDir}/envs/nextflow.yml"
-        
-        maxForks 6
+    output:
+        set val("${expName}-${species}"), file("matrices/counts_mtx.zip") into NEW_COUNT_MATRICES
+        set val("${expName}-${species}"), file("matrices/tpm_mtx.zip") optional true into NEW_TPM_MATRICES
+        set val("${expName}-${species}"), file("matrices/kallisto_stats.tsv") optional true into NEW_KALLISTO_STATS
+        set val("${expName}-${species}"), file("matrices/alevin_stats.tsv") optional true into NEW_ALEVIN_STATS
 
-        publishDir "$SCXA_RESULTS/$expName/$species/aggregation", mode: 'copy', overwrite: true
-        
-        memory { 4.GB * task.attempt }
-        errorStrategy { task.exitStatus == 130 || task.exitStatus == 137 || task.attempt < 3 ? 'retry' : 'finish' }
-        maxRetries 20
-        
-        input:
-            set val(tags), val(expName), val(species), file('quant_results/??/protocol'), file('quant_results/??/*'), file('quant_results/??/*') from GROUPED_QUANTIFICATION_RESULTS   
-
-        output:
-            set val(expName), val(species), file("matrices/counts_mtx.zip") into COUNT_MATRICES
-            set val(expName), val(species), file("matrices/tpm_mtx.zip") optional true into TPM_MATRICES
-            set val(expName), val(species), file("matrices/kallisto_stats.tsv") optional true into KALLISTO_STATS
-            set val(expName), val(species), file("matrices/alevin_stats.tsv") optional true into ALEVIN_STATS
-
-        """
-            submitAggregationWorkflow.sh "$expName" "$species"
-        """
-    }
+    """
+        submitAggregationWorkflow.sh "$expName" "$species"
+    """
 }
 
-COUNT_MATRICES
+NEW_COUNT_MATRICES
     .into{
-        COUNT_MATRICES_FOR_CELL_TO_LIB
-        COUNT_MATRICES_FOR_META_MATCHING
-        COUNT_MATRICES_FOR_TERTIARY
-        COUNT_MATRICES_FOR_BUNDLE
+        NEW_COUNT_MATRICES_FOR_CELLMETA
+        NEW_COUNT_MATRICES_FOR_CELL_TO_LIB
+        NEW_COUNT_MATRICES_FOR_META_MATCHING
+        NEW_COUNT_MATRICES_FOR_TERTIARY
+        NEW_COUNT_MATRICES_FOR_BUNDLING
     }
-
 
 // Get channel with the first config file for each exp/ species pair. For when
 // we need a config but don't need the protocol-specific bits, for example a
 // process needs to know the column with technical replicates etc.
 
-TAGS_FOR_TERTIARY                                           // tag, expname, species, protocol
-    .join(PRE_CONF_FOR_TERTIARY)                            // tag, expname, species, protocol, conf, confsdrf, confcells
-    .groupTuple( by: [1,2] )                                // [tag], expname, species, [protocol], [conf], [confsdrf], [confcells]
-    .map{ r -> tuple(r[1], r[2], r[4][0], r[5][0]) }        // expname, species, conf, confsdrf
-    .join(COUNT_MATRICES_FOR_CELL_TO_LIB, by: [0,1])        // expname, species, conf, confsdrf, countmatrix
-    .join(IS_DROPLET_EXP_SPECIES_FOR_CELLMETA, by: [0,1])   // expname, species, conf, confsdrf, countmatrix, isdroplet
-    .set{PRE_TERTIARY_INPUTS} 
+IS_DROPLET_EXP_SPECIES_FOR_CELLMETA         // esTag, isDroplet
+    .join(CONF_BY_EXP_SPECIES_FOR_CELLMETA) // esTag, isDroplet, confFile
+    .join(NEW_COUNT_MATRICES_FOR_CELLMETA)  // esTag, isDroplet, confFile, countMatrix
+    .set{
+        CELLMETA_INPUTS
+    }
 
-// Separate Droplet from non-droplet
+// Separate Droplet from non-droplet, to allow for some specialised processing
 
 DROPLET_CELL_TO_LIB_INPUT = Channel.create()
 SMART_CELL_TO_LIB_INPUT = Channel.create()
 
-PRE_TERTIARY_INPUTS.map{r -> tuple(r[0], r[1], r[2], r[4], r[5], file('NO_FILE')) }.choice( DROPLET_CELL_TO_LIB_INPUT, SMART_CELL_TO_LIB_INPUT ) {a -> 
-    a[4] == 'True' ? 0 : 1
-}
+CELLMETA_INPUTS
+    .map{r -> tuple(r[0], r[1], r[2], r[3], file('NO_FILE')) }
+    .choice( DROPLET_CELL_TO_LIB_INPUT, SMART_CELL_TO_LIB_INPUT ) {a -> 
+        a[1] == 'True' ? 0 : 1
+    }
 
 // SMART does not need the cell/lib mapping, so pass the empty value through
 
 SMART_CELL_TO_LIB_INPUT
-    .map{ r -> tuple(r[0], r[1], r[5]) }
+    .map{ r -> tuple(r[0], r[4]) }
     .set{SMART_CELL_TO_LIB}
-   
+
 // Make a cell-run mapping, required by the SDRF condense process to 'explode'
 // the SDRF annotations
 
@@ -870,10 +998,10 @@ process cell_run_mapping {
     cache 'deep'
     
     input:
-        set val(expName), val(species), file(confFile), file(countMatrix), val(isDroplet), file(emptyFile) from DROPLET_CELL_TO_LIB_INPUT
+        set val(esTag), val(isDroplet), file(confFile), file(countMatrix), file(emptyFile) from DROPLET_CELL_TO_LIB_INPUT
  
     output:
-        set val(expName), val(species), file('cell_to_library.txt') into DROPLET_CELL_TO_LIB
+        set val(esTag), file('cell_to_library.txt') into DROPLET_CELL_TO_LIB
  
     """
     makeCellLibraryMapping.sh $countMatrix $confFile cell_to_library.txt 
@@ -883,15 +1011,17 @@ process cell_run_mapping {
 // Now make a condensed SDRF file. For this to operate correctly with droplet
 // data, the cell-library mappings file must be present
 
-SMART_CELL_TO_LIB
-    .concat(DROPLET_CELL_TO_LIB)
-    .join(META_WITH_SPECIES_FOR_TERTIARY, by: [0,1])
+ES_TAGS_FOR_CONDENSE
+    .join(SMART_CELL_TO_LIB.concat(DROPLET_CELL_TO_LIB))
+    .join(META_WITH_SPECIES_FOR_TERTIARY)
     .set{
        CONDENSE_INPUTS
    }
 
 process condense_sdrf {
         
+    publishDir "$SCXA_RESULTS/$expName/$species/metadata", mode: 'copy', overwrite: true
+    
     cache 'deep'
         
     maxForks 2
@@ -903,10 +1033,10 @@ process condense_sdrf {
     maxRetries 10
 
     input:
-        set val(expName), val(species), file(cell_to_lib), file(idfFile), file(origSdrfFile), file(cellsFile) from CONDENSE_INPUTS 
+        set val(esTag), val(expName), val(species), file(cell_to_lib), file(idfFile), file(origSdrfFile), file(cellsFile) from CONDENSE_INPUTS 
 
     output:
-        set val(expName), val(species), file("${expName}.${species}.condensed-sdrf.tsv") into CONDENSED 
+        set val(esTag), file("${expName}.${species}.condensed-sdrf.tsv") into CONDENSED 
 
     """
     echo -e "exclusions: $ZOOMA_EXCLUSIONS"
@@ -917,7 +1047,7 @@ process condense_sdrf {
 
 CONDENSED.into{
     CONDENSED_FOR_META
-    CONDENSED_FOR_BUNDLE
+    CONDENSED_FOR_BUNDLING
 }
 
 // 'unmelt' the condensed SDRF to get a metadata table to pass for tertiary
@@ -936,19 +1066,21 @@ process unmelt_condensed_sdrf {
     maxRetries 20
     
     input:
-        set val(expName), val(species), file(condensedSdrf) from CONDENSED_FOR_META
+        set val(esTag), file(condensedSdrf) from CONDENSED_FOR_META
 
     output:
-       set val(expName), val(species), file("${expName}.metadata.tsv") into UNMELTED_META 
+       set val(esTag), file("${esTag}.metadata.tsv") into UNMELTED_META 
         
     """
-    unmelt_condensed.R -i $condensedSdrf -o ${expName}.metadata.tsv --retain-types --has-ontology
+    unmelt_condensed.R -i $condensedSdrf -o ${esTag}.metadata.tsv --retain-types --has-ontology
     """        
 }
 
 // Match the cell metadata to the expression matrix 
 
 process match_metadata_to_cells {
+    
+    publishDir "$SCXA_RESULTS/$expName/$species/metadata", mode: 'copy', overwrite: true
     
     cache 'deep'
     
@@ -959,128 +1091,80 @@ process match_metadata_to_cells {
     maxRetries 20
 
     input:
-        set val(expName), val(species), file(cellMeta), file(countMatrix) from UNMELTED_META.join(COUNT_MATRICES_FOR_META_MATCHING, by: [0,1])
+        set val(esTag), file(cellMeta), val(expName), val(species), file(countMatrix) from UNMELTED_META.join(ES_TAGS_FOR_META_MATCHING).join(NEW_COUNT_MATRICES_FOR_META_MATCHING)
 
     output:
-       set val(expName), val(species), file("${expName}.metadata.matched.tsv") into MATCHED_META 
+       set val(esTag), file("${esTag}.metadata.matched.tsv") into NEW_MATCHED_META 
 
     """
-    matchMetadataToCells.sh $cellMeta $countMatrix ${expName}.metadata.matched.tsv 
+    matchMetadataToCells.sh $cellMeta $countMatrix ${esTag}.metadata.matched.tsv 
     """
 }
 
-MATCHED_META.into{
-    MATCHED_META_FOR_TERTIARY
-    MATCHED_META_FOR_BUNDLE
-}
+NEW_MATCHED_META
+    .concat(REUSED_MATCHED_META)
+    .into{
+        MATCHED_META_FOR_TERTIARY
+        MATCHED_META_FOR_BUNDLING
+    }
 
-// Tertiary analysis requires the count matrix, references, and droplet status
+// Run tertiary analysis anew. Input is newly aggregated studies and
+// pre-existing aggregations flagged for tertiary
 
-CONF_REF_BY_EXP_SPECIES_FOR_TERTIARY
-    .join(COUNT_MATRICES_FOR_TERTIARY, by: [0,1])
-    .join(MATCHED_META_FOR_TERTIARY, by: [0,1])
-    .join(IS_DROPLET_EXP_SPECIES_FOR_TERTIARY, by: [0,1])
+ES_TAGS_FOR_TERTIARY                                                                                            // esTag, expName, species
+    .join(NEW_COUNT_MATRICES_FOR_TERTIARY.concat(TO_RETERTIARY.map{ r -> tuple(r[0])}.join(REUSED_COUNT_MATRICES_FOR_TERTIARY)))       // esTag, expName, species, countMatrix
+    .join(REFERENCES_FOR_TERTIARY)                                                                              // esTag, expName, species, countMatrix, referenceFasta, referenceGtf, contIndex
+    .join(MATCHED_META_FOR_TERTIARY)                                                                            // esTag, expName, species, countMatrix, referenceFasta, referenceGtf, contIndex, cellMetadata
+    .join(IS_DROPLET_EXP_SPECIES_FOR_TERTIARY)                                                                  // esTag, expName, species, countMatrix, referenceFasta, referenceGtf, contIndex, cellMetadata, isDroplet
     .set{TERTIARY_INPUTS}
 
-if ( tertiaryWorkflow == 'scanpy-galaxy' ) {
-
-    // Re-use previous tertiary results
-
-    if (skipTertiary == 'yes' ){
-
-        process spoof_scanpy_galaxy {
-        
-            executor 'local'
-            input:
-                set val(expName), val(species), file(referenceFasta), file(referenceGtf), file(contIndex), file(confFile), file(countMatrix), file(cellMetadata), val(isDroplet) from TERTIARY_INPUTS
-            
-            output:
-                set val(expName), val(species), file("matrices/raw_filtered.zip"), file("matrices/filtered_normalised.zip"), file("clusters_for_bundle.txt"), file("umap"), file("tsne"), file("markers"), file('clustering_software_versions.txt') into TERTIARY_RESULTS
-        
-            """
-                ln -s $SCXA_RESULTS/$expName/$species/scanpy/matrices 
-                ln -s $SCXA_RESULTS/$expName/$species/scanpy/clusters_for_bundle.txt
-                ln -s $SCXA_RESULTS/$expName/$species/scanpy/umap 
-                ln -s $SCXA_RESULTS/$expName/$species/scanpy/tsne
-                ln -s $SCXA_RESULTS/$expName/$species/scanpy/markers
-                ln -s $SCXA_RESULTS/$expName/$species/scanpy/clustering_software_versions.txt
-            """
-        }
-
-    }else{
-
-        process scanpy_galaxy {
-            
-            cache 'deep'
-            
-            // Exit status of 3 is just Galaxy being annoying with history
-            // deletion, no cause to error
-
-            validExitStatus 0,3
-        
-            maxForks params.maxConcurrentScanpyGalaxy
-
-            conda "${baseDir}/envs/galaxy-workflow-executor.yml"
-
-            publishDir "$SCXA_RESULTS/$expName/$species/scanpy", mode: 'copy', overwrite: true
-            
-            memory { 4.GB * task.attempt }
-            errorStrategy { task.exitStatus == 130 || task.exitStatus == 137 || task.attempt<=3  ? 'retry' : 'ignore' }
-            maxRetries 3
-              
-            input:
-                set val(expName), val(species), file(referenceFasta), file(referenceGtf), file(contIndex), file(confFile), file(countMatrix), file(cellMetadata), val(isDroplet) from TERTIARY_INPUTS
-
-            output:
-                set val(expName), val(species), file("matrices/raw_filtered.zip"), file("matrices/filtered_normalised.zip"), file("clusters_for_bundle.txt"), file("umap"), file("tsne"), file("markers"), file('clustering_software_versions.txt') into TERTIARY_RESULTS
-
-            script:
- 
-                """
-                    submitTertiaryWorkflow.sh "$expName" "$species" "$countMatrix" "$referenceGtf" "$cellMetadata" "$isDroplet" "$galaxyCredentials"
-                """
-        }
-    }
-} else{
-
-    // Don't do tertiary analysis
+process tertiary {
     
-    process spoof_tertiary {
+    cache 'deep'
     
-        executor 'local'
-        
-        input:
-            set val(expName), val(species), file(referenceFasta), file(referenceGtf), file(contIndex), file(confFile), file(countMatrix), file(cellMetadata), val(isDroplet) from TERTIARY_INPUTS
+    // Exit status of 3 is just Galaxy being annoying with history
+    // deletion, no cause to error
 
-        output:
-            set val(expName), val(species), file("NOFILT"), file("NONORM"), file("NOCLUST"), file("NOUMAP"), file("NOTSNE"), file("NOMARKERS"), file('NOSOFTWARE') into TERTIARY_RESULTS
+    validExitStatus 0,3
+
+    maxForks params.maxConcurrentScanpyGalaxy
+
+    conda "${baseDir}/envs/galaxy-workflow-executor.yml"
+
+    publishDir "$SCXA_RESULTS/$expName/$species/scanpy", mode: 'copy', overwrite: true
+    
+    memory { 4.GB * task.attempt }
+    errorStrategy { task.exitStatus == 130 || task.exitStatus == 137 || task.attempt<=3  ? 'retry' : 'ignore' }
+    maxRetries 3
+      
+    input:
+        set val(esTag), val(expName), val(species), file(countMatrix), file(referenceFasta), file(referenceGtf), file(contIndex), file(cellMetadata), val(isDroplet) from TERTIARY_INPUTS
+
+    output:
+        set val(esTag), file("matrices/raw_filtered.zip"), file("matrices/filtered_normalised.zip"), file("clusters_for_bundle.txt"), file("umap"), file("tsne"), file("markers"), file('clustering_software_versions.txt') into NEW_TERTIARY_RESULTS
+
+    script:
 
         """
-            mkdir -p matrices
-            cp -p ${countMatrix} matrices 
-            touch NOFILT NONORM NOPCA NOCLUST NOUMAP NOTSNE NOMARKERS NOSOFTWARE
+            submitTertiaryWorkflow.sh "$expName" "$species" "$countMatrix" "$referenceGtf" "$cellMetadata" "$isDroplet" "$galaxyCredentials"
         """
-    }    
 }
 
-// Bundling requires pretty much everything, so we need to gather a few channels
+// Bundling requires pretty much everything, so we need to gather a few
+// channels. Input experiments are those with new tertiary analysis, plus those
+// with re-used tertiary analysis flagged for re-bundling
 
-TAGS_FOR_BUNDLE
-    .map{r -> tuple(r[1], r[2], r[3])}
-    .groupTuple( by: [0,1] )
-    .map{r -> tuple(r[0], r[1], r[2].join(","))}
-    .set{
-        PROTOCOLS_BY_EXP_SPECIES
-    }
-
-PROTOCOLS_BY_EXP_SPECIES
-    .join(CONF_REF_BY_EXP_SPECIES_FOR_BUNDLE, by: [0,1])
-    .join(CONDENSED_FOR_BUNDLE, by: [0,1])
-    .join(MATCHED_META_FOR_BUNDLE, by: [0,1])
-    .join(COUNT_MATRICES_FOR_BUNDLE,  by: [0,1])
-    .join(TPM_MATRICES, remainder: true, by: [0,1])
-    .join(TERTIARY_RESULTS, by: [0, 1])
-    .set { BUNDLE_INPUTS } 
+NEW_TERTIARY_RESULTS                                                
+    .concat(TO_REBUNDLE.join(REUSED_TERTIARY_RESULTS))                                  // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport
+    .join(ES_TAGS_FOR_BUNDLING)                                                         // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species
+    .join(PROTOCOLS_BY_EXP_SPECIES)                                                     // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList
+    .join(CONF_BY_EXP_SPECIES_FOR_BUNDLE)                                               // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList, confFile
+    .join(NEW_COUNT_MATRICES_FOR_BUNDLING.concat(REUSED_COUNT_MATRICES_FOR_BUNDLING))   // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList, confFile, rawMatrix
+    .join(NEW_TPM_MATRICES.concat(REUSED_TPM_MATRICES))                                 // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList, confFile, rawMatrix, tpmMatrix
+    .join(REFERENCES_FOR_BUNDLING)                                                      // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList, confFile, rawMatrix, tpmMatrix, referenceFasta, referenceGtf, contIndex
+    .join(CONDENSED_FOR_BUNDLING.concat(REUSED_CONDENSED))                              // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList, confFile, rawMatrix, tpmMatrix, referenceFasta, referenceGtf, contIndex, condensedSdrf
+    .join(MATCHED_META_FOR_BUNDLING)                                                    // esTag, filteredMatrix, normalisedMatrix, clusters, umap, tsne, markers, softwareReport, expName, species, protocolList, confFile, rawMatrix, tpmMatrix, referenceFasta, referenceGtf, contIndex, condensedSdrf, cellMetadata 
+    .set{BUNDLE_INPUTS}
 
 process bundle {
     
@@ -1093,7 +1177,7 @@ process bundle {
     maxRetries 20
     
     input:
-        set val(expName), val(species), val(protocolList), file(referenceFasta), file(referenceGtf), file(contaminationIndex), file(confFile), file(condensedSdrf), file(cellMeta), file(rawMatrix), file(tpmMatrix), file(filteredMatrix), file(normalisedMatrix), file(clusters), file('*'), file('*'), file('*'), file(softwareReport) from BUNDLE_INPUTS
+        set val(esTag), file(filteredMatrix), file(normalisedMatrix), file(clusters), file('*'), file('*'), file('*'), file(softwareReport), val(expName), val(species), val(protocolList), file(confFile), file(rawMatrix), file(tpmMatrix), file(referenceFasta), file(referenceGtf), file(contaminationIndex), file(condensedSdrf), file(cellMetadata) from BUNDLE_INPUTS
         
     output:
         file('bundle/software.tsv')
@@ -1136,8 +1220,46 @@ process bundle {
         file('bundleLines.txt') into NEW_BUNDLES
         
         """
-            submitBundleWorkflow.sh "$expName" "$species" "$protocolList" "$confFile" "$referenceFasta" "$referenceGtf" "$tertiaryWorkflow" "$condensedSdrf" "$cellMeta" "$rawMatrix" "$filteredMatrix" "$normalisedMatrix" "$tpmMatrix" "$clusters" markers tsne umap $softwareReport
+            submitBundleWorkflow.sh "$expName" "$species" "$protocolList" "$confFile" "$referenceFasta" "$referenceGtf" "$tertiaryWorkflow" "$condensedSdrf" "$cellMetadata" "$rawMatrix" "$filteredMatrix" "$normalisedMatrix" "$tpmMatrix" "$clusters" markers tsne umap $softwareReport
         """
+}
+
+// Bundle lines for things that haven't changed at all
+
+process get_not_updated_bundles {
+
+    input:
+        val expName from NOT_UPDATED_EXPERIMENTS.map{r -> r[0]}
+
+    output:
+        file('bundleLines.txt') into NOT_UPDATED_BUNDLES
+
+    """
+        ls \$SCXA_RESULTS/$expName/*/bundle/MANIFEST | while read -r l; do
+            species=\$(echo \$l | awk -F'/' '{print \$(NF-2)}' | tr -d \'\\n\')
+            echo -e "$expName\\t\$species\\t$SCXA_RESULTS/$expName/\$species/bundle"
+        done > bundleLines.txt
+
+    """
+}
+
+// Generate bundle lines for the things updated but not actually changed for
+// analysis
+
+process get_not_changed_bundles {
+
+    input:
+        set val(expName), val(species) from NOT_CHANGED_EXPERIMENTS_FOR_BUNDLES
+
+    output:
+         file('bundleLines.txt') into NOT_CHANGED_BUNDLES
+
+    """
+        # Update the manifest time stamps to prevent re-config next time
+        touch -m $SCXA_RESULTS/$expName/$species/bundle/MANIFEST
+
+        echo -e "$expName\\t$species\\t$SCXA_RESULTS/$expName/$species/bundle" > bundleLines.txt
+    """
 }
 
 // Record the completed bundles
@@ -1178,7 +1300,7 @@ process cleanup {
     """
 }
 
-// 
+// Make the HTML report 
 
 process report_table {
 

--- a/main.nf
+++ b/main.nf
@@ -271,15 +271,15 @@ process generate_configs {
     """
     # Cells file will be empty (from reminder: true above) for some experiments
     cells_options=
-    cells_filesize=$(stat --printf="%s" $(readlink ${cellsFile}))
-    if [ $cells_filesize -gt 0 ]; then
+    cells_filesize=\$(stat --printf="%s" \$(readlink ${cellsFile}))
+    if [ \$cells_filesize -gt 0 ]; then
         cells_options="--cells=$cellsFile --cell_meta_fields="$params.cellAnalysisFields""
     fi
 
     mkdir -p tmp
     sdrfToNfConf.R \
         --sdrf=\$(readlink $sdrfFile) \
-        --idf=$idfFile $cells_options\
+        --idf=$idfFile \$cells_options \
         --name=$expName \
         --verbose \
         --out_conf \$(pwd)

--- a/params.config
+++ b/params.config
@@ -8,5 +8,16 @@ params {
     //teriaryWorkflow = 'scanpy-workflow'
 
     islReferenceType = 'newest'
-    cellAnalysisFields = 'inferred cell type - ontology labels' 
+
+    // cellAnalysisFields are all the fields that will be used in tertiary
+    // analysis. Right now this is limited to the field used for cell type
+    // markers, but will likely be extended in future. This is the selection of
+    // fields for which changes trigger tertiary re-analysis
+    
+    //cellAnalysisFields = 'inferred cell type - ontology labels' 
+    cellAnalysisFields = 'inferred cell type,inferred cell type - ontology labels,inferred cell type - authors labels' 
+
+    // The specific field used for cell type analysis- should be part of
+    // cellAnalysisFields. The first of these that's found will be used
+    cellTypeField = 'inferred cell type,inferred cell type - ontology labels,inferred cell type - authors labels'
 }

--- a/params.config
+++ b/params.config
@@ -8,4 +8,5 @@ params {
     //teriaryWorkflow = 'scanpy-workflow'
 
     islReferenceType = 'newest'
+    cellAnalysisFields = 'inferred cell type - ontology labels' 
 }


### PR DESCRIPTION
This is a substantial set of changes for the control workflow to introduce the following improvements:

- sdrfToNfConf.R - now produces a file containing metadata pertinent only to tertiary analysis, where present in the sdrf/ cells file. Right now this is just cell types, but could be other things in future. Changes in this file in subsequent runs can be used to determine a need for tertiary re-analysis. 
- Logic rewired to save more intermediate files per run and remove the number of processes that need to be executed for cached results. 
- checkExperimentChanges.sh allocated a more central control role. We can now more effectively re-route experiments through workflow logic by tweaking this script. It returns a status code that dictates into which channel an experiment is routed, based both on the rerun parameters and the change status of workflow outputs. 
- flexibility with respect to cell type fields. We currently have an intermediate situation in the SCXA metadata where some experiments have been updated to use new cell type fields and others have not. A findCelltypeField.sh script determines which field is present and passes it to downstream processes. Outputs related to this field are labelled with it (e.g. differential cell type analysis).

Associated with related changes in production loading: https://github.com/ebi-gene-expression-group/db-scxa/pull/44, https://github.com/ebi-gene-expression-group/atlas-prod/pull/179.

I have now confirmed that new bundles produced using this PR are loaded correctly using the above PRs in production.

NOTE: I have made changes to the current production bundles that should prevent unnecessary re-runs, but some tertiary re-analysis will occur in response to previously undetected changes in tertiary-relevant metadata, once we deploy these changes. 