### PR TITLE
For private experiments use fastq files from a local directory path

### DIFF
--- a/bin/submitQuantificationWorkflow.sh
+++ b/bin/submitQuantificationWorkflow.sh
@@ -9,7 +9,8 @@ sdrfFile=$6
 referenceFasta=$7
 transcriptToGene=$8
 contaminationIndex=$9
-enaSshUser=$10
+enaSshUser=${10}
+privacyStatus=${11}
 
 # Remove existing results downstrea of this step
 
@@ -40,6 +41,16 @@ if [ $isCa -eq 0 ]; then
   # directory, but files will be available via symlinks in a flattened
   # directory under /analysis
   manualDownloadFolder=$caDir/analysis/data
+
+elif [ "$privacyStatus" != 'public' ]; then
+    
+  if [ -z "$SCXA_PRIVATE_PATH" ]; then
+    echo "$expName is a private experiment, but SCXA_PRIVATE_PATH is not set in the environment" 1>&2
+    exit 1
+  fi
+
+  expType=$(echo -n "$expName" | awk -F '-' '{print $2}')
+  manualDownloadFolder=$SCXA_PRIVATE_PATH/$expType/$expName
 fi
 
 mkdir -p $quantWorkDir

--- a/bin/submitQuantificationWorkflow.sh
+++ b/bin/submitQuantificationWorkflow.sh
@@ -47,6 +47,9 @@ elif [ "$privacyStatus" != 'public' ]; then
   if [ -z "$SCXA_PRIVATE_PATH" ]; then
     echo "$expName is a private experiment, but SCXA_PRIVATE_PATH is not set in the environment" 1>&2
     exit 1
+  elif [ "$privacyStatus" != 'private' ]; then
+    echo "Invalid privacy status: '$privacyStatus'"
+    exit 1
   fi
 
   expType=$(echo -n "$expName" | awk -F '-' '{print $2}')

--- a/main.nf
+++ b/main.nf
@@ -711,7 +711,7 @@ process check_privacy {
 
     """
     privacyStatus=\$(wget -O - http://peach.ebi.ac.uk:8480/api/privacy.txt?acc=${expName} 2>/dev/null | tr "\\t" "\\n" | awk -F':' '/privacy/ {print \$2}')
-    echo -n "$privacyStatus"
+    echo -n "\$privacyStatus"
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -710,7 +710,7 @@ process check_privacy {
         set val(espTag), stdout into PRIVACY_STATUS
 
     """
-    wget  -O - http://peach.ebi.ac.uk:8480/api/privacy.txt?acc={$expName} 2>/dev/null | tr "\t" "\n" | awk -F':' '/privacy/ {print $2}'
+    wget  -O - http://peach.ebi.ac.uk:8480/api/privacy.txt?acc={$expName} 2>/dev/null | tr "\t" "\n" | awk -F':' '/privacy/ {print \$2}'
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -710,7 +710,8 @@ process check_privacy {
         set val(espTag), stdout into PRIVACY_STATUS
 
     """
-    wget  -O - http://peach.ebi.ac.uk:8480/api/privacy.txt?acc=${expName} 2>/dev/null | tr "\\t" "\\n" | awk -F':' '/privacy/ {print \$2}'
+    privacyStatus=\$(wget -O - http://peach.ebi.ac.uk:8480/api/privacy.txt?acc=${expName} 2>/dev/null | tr "\\t" "\\n" | awk -F':' '/privacy/ {print \$2}')
+    echo -n "$privacyStatus"
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -710,7 +710,7 @@ process check_privacy {
         set val(espTag), stdout into PRIVACY_STATUS
 
     """
-    wget  -O - http://peach.ebi.ac.uk:8480/api/privacy.txt?acc={$expName} 2>/dev/null | tr "\t" "\n" | awk -F':' '/privacy/ {print \$2}'
+    wget  -O - http://peach.ebi.ac.uk:8480/api/privacy.txt?acc=${expName} 2>/dev/null | tr "\\t" "\\n" | awk -F':' '/privacy/ {print \$2}'
     """
 }
 
@@ -912,7 +912,7 @@ process smart_quantify {
     maxRetries 10
     
     input:
-        set val(espTag), val(isDroplet), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex), file(transcriptToGene), file(privacyStatus) from SMART_INPUTS
+        set val(espTag), val(isDroplet), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex), file(transcriptToGene), val(privacyStatus) from SMART_INPUTS
         val flag from INIT_DONE_SMART
 
     output:
@@ -941,7 +941,7 @@ process droplet_quantify {
     errorStrategy { task.attempt<=5 ? 'retry' : 'ignore' }
 
     input:
-        set val(espTag), val(isDroplet), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex), file(transcriptToGene), file(privacyStatus) from DROPLET_INPUTS
+        set val(espTag), val(isDroplet), val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary), file(referenceFasta), file(referenceGtf), val(contaminationIndex), file(transcriptToGene), val(privacyStatus) from DROPLET_INPUTS
         val flag from INIT_DONE_DROPLET
 
     output:


### PR DESCRIPTION
This is a fairly simple set of changes to deal with private experiments:

1. derive privacy status using the peach API
2. pass privacy status to quantification submission script
3. said script uses a pre-existing 'manual download' functionality to specify a local directory than can be predicted from the experiment ID using a pattern supplied by @anjaf , but provided via an environment variable. 

This is currently raised against the branch from https://github.com/ebi-gene-expression-group/scxa-control-workflow/pull/22 to illustrate the changes, but will be merged to develop after that branch. 