### PR TITLE
Filter completed list to remove exclusions

### DIFF
--- a/bin/submitIndependentControlWorkflows.sh
+++ b/bin/submitIndependentControlWorkflows.sh
@@ -138,7 +138,14 @@ while read -r idfFile; do
     fi
 done <<< "$(ls $SCXA_WORKFLOW_ROOT/metadata/*/*/*.idf.txt)"
 
-# List all finished bundles for loading
-ls $SCXA_WORKFLOW_ROOT/results/*/*/bundle/MANIFEST | while read -r l; do dirname $l; done | awk -F'/' '{OFS="\t";} {print $(NF-2),$(NF-1),$0}' > results/all.done.txt
+# List all finished bundles for loading, exluding anything that might have been
+# added to the excluded set after completion
 
+ls $SCXA_WORKFLOW_ROOT/results/*/*/bundle/MANIFEST | while read -r l; do dirname $l; done | awk -F'/' '{OFS="\t";} {print $(NF-2),$(NF-1),$0}' | while read -r m; do
+    exp=$(echo -e "$m" | awk '{print $1}');
+    grep "^$exp$(printf '\t')" $SCXA_RESULTS/excluded.txt > /dev/null;
+    if [ $? -ne 0 ]; then
+        echo -e "$m";
+    fi;
+done > $SCXA_RESULTS/all.done.txt
 rm $submissionMarker


### PR DESCRIPTION
This PR filters the list of completed studies to include things excluded following successful analysis, rather than just those things that failed to analyse.