### PR TITLE
Feature/meta marker consistency

### DIFF
--- a/bin/submitBundleWorkflow.sh
+++ b/bin/submitBundleWorkflow.sh
@@ -9,17 +9,16 @@ referenceGtf=$6
 tertiaryWorkflow=$7
 condensedSdrf=$8
 cellMeta=$9
-cellTypeField=${10}
-rawMatrix=${11}
-filteredMatrix=${12}
-normalisedMatrix=${13}
-tpmMatrix=${14}
-clusters=${15}
-markersDir=${16}
-tsneDir=${17}
-umapDir=${18}
-softwareReport=${19}
-projectFile=${20}
+rawMatrix=${10}
+filteredMatrix=${11}
+normalisedMatrix=${12}
+tpmMatrix=${13}
+clusters=${14}
+markersDir=${15}
+tsneDir=${16}
+umapDir=${17}
+softwareReport=${18}
+projectFile=${19}
 
 RESULTS_ROOT=$PWD
 SUBDIR="$expName/$species/bundle"     
@@ -51,7 +50,6 @@ nextflow run \
     --resultsRoot $RESULTS_ROOT \
     --protocolList ${protocolList} \
     --cellMetadata ${cellMeta} \
-    --cellTypeField ${cellTypeField} \
     --condensedSdrf ${condensedSdrf} \
     --rawMatrix ${rawMatrix} $TPM_OPTIONS \
     --referenceFasta $referenceFasta \

--- a/bin/submitTertiaryWorkflow.sh
+++ b/bin/submitTertiaryWorkflow.sh
@@ -90,16 +90,12 @@ if [ $? -eq 0 ]; then
     mkdir -p markers
     set +e
                     
-    marker_files=$(ls markers_* 2>/dev/null | grep -v markers_louvain_resolution)
+    marker_files=$(ls markers_* 2>/dev/null | grep -v markers_resolution)
     if [ $? -ne 0 ]; then
         echo "No marker files present"
         touch markers/NOMARKERS
     else
         mv $marker_files markers
-    fi
-
-    if [ -e 'celltype_markers.tsv' ]; then
-        mv celltype_markers.tsv markers/${cell_type_field}_markers.tsv
     fi
 
     rm -f state_file


### PR DESCRIPTION
As per https://github.com/ebi-gene-expression-group/scxa-bundle-workflow/pull/10, the bundling sub-workflow no longer needs explicit specification of cell type field and will derive necessary information from the marker files present. 

There's also a fix here to account for changes in the tertiary workflow (see https://github.com/ebi-gene-expression-group/scxa-workflows/pull/21) which mean a string ('louvain_') is no longer part of the received file names.