### PR TITLE
Allow for SRA file as source of read files

### DIFF
--- a/bin/parseNfConfig.py
+++ b/bin/parseNfConfig.py
@@ -20,6 +20,7 @@ with open(args.param_file, 'r') as nf_file:
         if (not 'includeConfig' in line) and (not '}' in line) and (not line.startswith('//')):
             line = line.replace('{', ':')
             line = line.replace('=', ':')
+            line = line.replace('//', '#')
             nf_content += line
 
 # Parse content as YAML

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -199,6 +199,7 @@ sc.quality.col <- getActualColnames('single cell quality', sdrf)
 libary.layout.col <- getActualColnames('library layout', sdrf)
 spike.in.col <- getActualColnames('spike_in', sdrf)
 fastq.col <- getActualColnames('fastq uri', sdrf)
+sra.col <- getActualColnames('sra uri', sdrf)
 cell.count.col <- getActualColnames('cell count', sdrf)
 hca.bundle.uuid.col <- getActualColnames('HCA bundle uuid', sdrf)
 hca.bundle.version.col <- getActualColnames('HCA bundle version', sdrf)
@@ -251,6 +252,7 @@ sc.droplet.protocols <- c('10xv1', '10xv1a', '10xv1i', '10xv2', '10xv3', 'drop-s
 
 is.singlecell <- FALSE
 is.hca <- ! is.null(hca.bundle.uuid.col)
+is.sra <- ! is.null(sra.col)
 
 if ( ! is.null(protocol.col)){
 
@@ -296,10 +298,9 @@ for (comp in names(compare)){
     q(status=1)
   }
 }
-
 ## Verify presence of mandatory columns (SDRF) and regularise names
 
-cols.for.download <- ifelse(is.hca, c(hca.bundle.uuid.col, hca.bundle.version.col) , fastq.col)
+cols.for.download <- ifelse(is.hca, c(hca.bundle.uuid.col, hca.bundle.version.col) , ifelse(is.sra, sra.col, fastq.col))
 expected.cols <- c("Source Name")
 expected.comment.cols <- c("LIBRARY_STRATEGY","LIBRARY_SOURCE","LIBRARY_SELECTION","LIBRARY_LAYOUT",cols.for.download)
 expected.characteristic.cols <- c()
@@ -1027,7 +1028,7 @@ configs <- lapply(species_list, function(species){
       umi_field <- getActualColnames('umi barcode read', sdrf)
       cb_field <- getActualColnames('cell barcode read', sdrf)
       
-      if (! is.hca){
+      if (! any(is.hca, is.sra)){
         uri_cols <- which(colnames(sdrf) == fastq.col)
         if (length(uri_cols) < 2 ){
           perror('Less than 2 FASTQ URI fields supplied for droplet experiment- expect at least two, probably one for barcode/UMI, one for cDNA.')
@@ -1070,6 +1071,8 @@ configs <- lapply(species_list, function(species){
 
         if (is.hca){
           species.protocol.sdrf[[uri_field]] <- paste('hca', species.protocol.sdrf[[hca.bundle.uuid.col]], species.protocol.sdrf[[hca.bundle.version.col]], files, sep='/')
+        }else if(is.sra){
+          species.protocol.sdrf[[uri_field]] <- paste(species.protocol.sdrf[[sra.col]], files, sep='/')
         }else{
 
           nlibs <- nrow(species.protocol.sdrf)

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -1072,7 +1072,7 @@ configs <- lapply(species_list, function(species){
         if (is.hca){
           species.protocol.sdrf[[uri_field]] <- paste('hca', species.protocol.sdrf[[hca.bundle.uuid.col]], species.protocol.sdrf[[hca.bundle.version.col]], files, sep='/')
         }else if(is.sra){
-          species.protocol.sdrf[[uri_field]] <- paste(species.protocol.sdrf[[sra.col]], files, sep='/')
+          species.protocol.sdrf[[uri_field]] <- paste('sra', species.protocol.sdrf[[sra.col]], files, sep='/')
         }else{
 
           nlibs <- nrow(species.protocol.sdrf)

--- a/envs/atlas-fastq-provider.yml
+++ b/envs/atlas-fastq-provider.yml
@@ -1,4 +1,4 @@
 name: atlas-fastq-provider
 dependencies:
-  - atlas-fastq-provider=0.1.10
+  - atlas-fastq-provider=0.2.3
   - pyyaml


### PR DESCRIPTION
Edit pipeline configuration step to allow for SRA file input rather than direct fastq file download. The config process creates a prefixed URI (sra/*) which is passed through e.g. scax-droplet-quanitification-workflow to the atlas fastq provider, where it triggers download and unpacking of the SRA files, with fastqs being provided back to the workflow.

See also:

 - https://github.com/ebi-gene-expression-group/atlas-fastq-provider/pull/6
 - https://github.com/ebi-gene-expression-group/scxa-droplet-quantification-workflow/pull/12