### PR TITLE
prioritise new cell type fields

### DIFF
--- a/params.config
+++ b/params.config
@@ -19,5 +19,5 @@ params {
 
     // The specific field used for cell type analysis- should be part of
     // cellAnalysisFields. The first of these that's found will be used
-    cellTypeField = 'inferred cell type - ontology labels,inferred cell type - authors labels'
+    cellTypeField = 'authors cell type - ontology labels,authors cell type,inferred cell type - ontology labels,inferred cell type - authors labels'
 }


### PR DESCRIPTION
Prepare for new cell type fields when preparing tertiary-relevant metadata.

See also:

- https://github.com/ebi-gene-expression-group/db-scxa/pull/54
- https://github.com/ebi-gene-expression-group/experiment_metadata/pull/24

This will trigger a tertiary re-analysis in all impacted datasets, but that's desirable anyway to incorporate recent improvements  to tertiary analysis.