### PR TITLE
Don't ignore errors in config step

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -263,8 +263,6 @@ process check_controlled_access{
     conda 'pyyaml' 
     
     cache false
-    
-    errorStrategy 'ignore'
 
     input:
         set val(expName), val(species), val(protocol), file(confFile), file(metaForQuant), file(metaForTertiary) from CONF_ANALYSIS_META_BY_EXP_SPECIES_PROTOCOL

--- a/main.nf
+++ b/main.nf
@@ -193,8 +193,6 @@ META_WITH_SPECIES_IDF
 process generate_configs {
 
     cache 'deep'
-    
-    errorStrategy 'ignore'
 
     conda 'r-optparse r-data.table r-workflowscriptscommon pyyaml'
 


### PR DESCRIPTION
The pipeline currently attempts to ignore config errors in main.nf. This is a relic of an earlier time when main.nf handled multiple experiments at once, and wanted to proceed with all experiments even if one of them failed config.

We now coordinate all experiments separately with an independent workflow run for each. Consequently, we want config errors to trigger failure of the whole workflow.