### PR TITLE
Add "single nucleus rna sequencing" to list of valid experiment types

### DIFF
--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -434,7 +434,7 @@ if ( !is.null(opt$idf_file) ) {
   if (is.singlecell && exp.type.name == 'bulk'){
     addWarning("IDF shows bulk experiment ('RNA-seq of coding RNA'), but SDRF indicated single-cell (so should be 'RNA-seq of coding RNA from single cells')")
   } else if ( exp.type.name %in% c('single_cell', 'single_nucleus') && ! is.singlecell ){
-    addWarning(paste("IDF shows non-bulk data ('", exp.type.name, "'), but SDRF indicated bulk (so should be 'RNA-seq of coding RNA')")
+    addWarning(paste("IDF shows non-bulk data ('", exp.type.name, "'), but SDRF indicated bulk (so should be 'RNA-seq of coding RNA')"))
   } 
  
   ## - Experimental Factor Name (mandatory) exist in the SDRF

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -433,10 +433,9 @@ if ( !is.null(opt$idf_file) ) {
 
   if (is.singlecell && exp.type.name == 'bulk'){
     addWarning("IDF shows bulk experiment ('RNA-seq of coding RNA'), but SDRF indicated single-cell (so should be 'RNA-seq of coding RNA from single cells')")
-  } else if ( exp.type.name == 'single_cell' && ! is.singlecell ){
-    addWarning("IDF shows single cell ('RNA-seq of coding RNA from single cells'), but SDRF indicated bulk (so should be 'RNA-seq of coding RNA')")
-  } else if ( exp.type.name == 'single_cell_nucleus' && ! is.singlecell ){
-    addWarning("IDF shows single cell ('single nucleus rna sequencing'), but SDRF indicated bulk (so should be 'RNA-seq of coding RNA')")  
+  } else if ( exp.type.name %in% c('single_cell', 'single_nucleus') && ! is.singlecell ){
+    addWarning(paste("IDF shows non-bulk data ('", exp.type.name, "'), but SDRF indicated bulk (so should be 'RNA-seq of coding RNA')")
+  } 
   } 
  
   ## - Experimental Factor Name (mandatory) exist in the SDRF

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -420,7 +420,7 @@ if ( !is.null(opt$idf_file) ) {
   ## Check the experiment type
     
   exp.type <- tolower(idf["aeexperimenttype",1])
-  valid.exp.types = c( single_cell = "RNA-seq of coding RNA from single cells", single_cell_nucleus = "single nucleus rna sequencing", bulk = "RNA-seq of coding RNA" )
+  valid.exp.types = c( single_cell = "RNA-seq of coding RNA from single cells", single_nucleus = "single nucleus rna sequencing", bulk = "RNA-seq of coding RNA" )
     
   if ( ! exp.type %in% tolower(valid.exp.types) ){
     perror("IDF error in AEExperimentType: Invalid value (", exp.type,") expected ",paste(valid.exp.types, sep=" or ", collapse=" or "))

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -436,7 +436,6 @@ if ( !is.null(opt$idf_file) ) {
   } else if ( exp.type.name %in% c('single_cell', 'single_nucleus') && ! is.singlecell ){
     addWarning(paste("IDF shows non-bulk data ('", exp.type.name, "'), but SDRF indicated bulk (so should be 'RNA-seq of coding RNA')")
   } 
-  } 
  
   ## - Experimental Factor Name (mandatory) exist in the SDRF
   

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -420,7 +420,7 @@ if ( !is.null(opt$idf_file) ) {
   ## Check the experiment type
     
   exp.type <- tolower(idf["aeexperimenttype",1])
-  valid.exp.types = c( single_cell = "RNA-seq of coding RNA from single cells", bulk = "RNA-seq of coding RNA" )
+  valid.exp.types = c( single_cell = "RNA-seq of coding RNA from single cells", single_cell_nucleus = "single nucleus rna sequencing", bulk = "RNA-seq of coding RNA" )
     
   if ( ! exp.type %in% tolower(valid.exp.types) ){
     perror("IDF error in AEExperimentType: Invalid value (", exp.type,") expected ",paste(valid.exp.types, sep=" or ", collapse=" or "))
@@ -435,6 +435,8 @@ if ( !is.null(opt$idf_file) ) {
     addWarning("IDF shows bulk experiment ('RNA-seq of coding RNA'), but SDRF indicated single-cell (so should be 'RNA-seq of coding RNA from single cells')")
   } else if ( exp.type.name == 'single_cell' && ! is.singlecell ){
     addWarning("IDF shows single cell ('RNA-seq of coding RNA from single cells'), but SDRF indicated bulk (so should be 'RNA-seq of coding RNA')")
+  } else if ( exp.type.name == 'single_cell_nucleus' && ! is.singlecell ){
+    addWarning("IDF shows single cell ('single nucleus rna sequencing'), but SDRF indicated bulk (so should be 'RNA-seq of coding RNA')")  
   } 
  
   ## - Experimental Factor Name (mandatory) exist in the SDRF


### PR DESCRIPTION
The curation team has started to include "single nucleus RNA sequencing" as a valid value for the `AEExperimentType` field in the IDF files. However, the SCXA pipeline is not recognising this as valid, and therefore failing, e.g.
```
  [ERROR] IDF error in AEExperimentType: Invalid value (single nucleus rna sequencing) expected RNA-seq of coding RNA from single cells or RNA-seq of coding RNA
```
This PR aims to fix that.
