### PR TITLE
Update sdrfToNfConf.R

### DIFF
--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -1075,9 +1075,15 @@ configs <- lapply(species_list, function(species){
           species.protocol.sdrf[[uri_field]] <- paste('sra', species.protocol.sdrf[[sra.col]], files, sep='/')
         }else{
 
+          # For each library we check if there is a fastq URI that can supply the file
+          uri_select <- apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files)         
+                              
+          missing_uri_files <- files[which(! apply(apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files), 1, any))]
+          if (length(missing_file_uris) > 0){
+            stop(paste("Can't find URIs matching files:", paste(missing_uri_files, collapse=',')))
+          }
+                                                         
           nlibs <- nrow(species.protocol.sdrf)
-          uri_select <- apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files)
-          
           if (nlibs > 1){
             uri_fields <- uri_cols[apply(uri_select, 1, function(x) which(x))]
           }else{


### PR DESCRIPTION
This PR produces a more informative error when mis-curation leads to files for libraries not matching URIs on the same SDRF row.

In more detail, `uri_select` is a logical matrix with a row for every SDRF row and a column for every FASTQ_URI column:

```
> uri_select
      Comment[FASTQ_URI] Comment[FASTQ_URI].1
 [1,]              FALSE                FALSE
 [2,]              FALSE                FALSE
 [3,]              FALSE                FALSE
 [4,]              FALSE                FALSE
 [5,]              FALSE                FALSE
 [6,]              FALSE                FALSE
 [7,]              FALSE                FALSE
```

For each of the read files it should be possible to locate a matching URI (using `basename`), which should lead to at least one TRUE value in each row of this matrix. Failure to check this is currently leading to an error further down the script:

```
Error in `[.data.frame`(species.protocol.sdrf, , config_fields) : 
  undefined columns selected
Calls: lapply -> FUN -> lapply -> FUN -> [ -> [.data.frame
Execution halted
```

The code change here makes sure that each row has a true value before proceeding.