### PR TITLE
Ignore anndata objects for analysis

### DIFF
--- a/bin/submitIndependentControlWorkflows.sh
+++ b/bin/submitIndependentControlWorkflows.sh
@@ -139,7 +139,7 @@ while read -r idfFile; do
         fi
     fi
 
-done <<< "$(ls $SCXA_WORKFLOW_ROOT/metadata/*/*/*.idf.txt)"
+done <<< "$(ls $SCXA_WORKFLOW_ROOT/metadata/*/*/*.idf.txt | grep -v ANND)"
 
 # List all finished bundles for loading, exluding anything that might have been
 # added to the excluded set after completion


### PR DESCRIPTION
An a path for externally analysed datasets is currently being implemented, for which experiments have the E-ANND prefix. We don't want these picked up for standard analysis.