### PR TITLE
Correct variable name

### DIFF
--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -1079,7 +1079,7 @@ configs <- lapply(species_list, function(species){
           uri_select <- apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files)         
                               
           missing_uri_files <- files[which(! apply(apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files), 1, any))]
-          if (length(missing_file_uris) > 0){
+          if (length(missing_uri_files) > 0){
             stop(paste("Can't find URIs matching files:", paste(missing_uri_files, collapse=',')))
           }
                                                          


### PR DESCRIPTION
This is related to the PR https://github.com/ebi-gene-expression-group/scxa-control-workflow/pull/34 
We didn't notice a typo in the var name, which is causing now the error:
```
Command error:
  Error in FUN(X[[i]], ...) : object 'missing_file_uris' not found
  Calls: lapply -> FUN -> lapply -> FUN
  Execution halted
```