### PR TITLE
Changes necessary to change from alevin to alevin-fry in scxa droplet quantification workflow

### DIFF
--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -47,7 +47,7 @@ fi
 refinfo=$( refgenie list -g $reference )
 
 fasta=$(refgenie seek $reference/fasta_txome:cdna_$referenceType)
-genome_fasta=$(refgenie seek $reference/fasta:genome)
+genome_fasta=$(refgenie seek $species--newest/fasta:genome)
 gtf=$(refgenie seek $reference/ensembl_gtf:$referenceType )
 
 kallisto_version=$(grep "kallisto=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_smart-seq_quantification/envs/kallisto.yml | awk -F'=' '{print $2}' | tr -d '\n')

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -47,7 +47,7 @@ fi
 refinfo=$( refgenie list -g $reference )
 
 fasta=$(refgenie seek $reference/fasta_txome:cdna_$referenceType)
-genome_fasta=$(refgenie seek ${species}--current/fasta:genome)
+genome_fasta=$(refgenie seek ${species}--newest/fasta:genome)
 gtf=$(refgenie seek $reference/ensembl_gtf:$referenceType )
 
 kallisto_version=$(grep "kallisto=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_smart-seq_quantification/envs/kallisto.yml | awk -F'=' '{print $2}' | tr -d '\n')

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -59,6 +59,6 @@ salmon_index=$(refgenie seek $reference/salmon_index:cdna_${referenceType}--salm
 mkdir -p $outDir
 ln -s $fasta $outDir/$(find_orig_refgenie_asset_name $fasta)
 ln -s $genome_fasta ${outDir}/${genome_fasta})
-ln -s $gtf $outDir/$(find_orig_refgenie_asset_name $gtf)
+ln -s $gtf $outDir/$(find_orig_refgenie_asset_name $gtf
 ln -s $(dirname $salmon_index) $outDir/salmon_index
 ln -s $(ls $(dirname $kallisto_index)/*.idx) $outDir/$(find_orig_refgenie_asset_name $fasta).idx

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -47,7 +47,7 @@ fi
 refinfo=$( refgenie list -g $reference )
 
 fasta=$(refgenie seek $reference/fasta_txome:cdna_$referenceType)
-genome_fasta=$(refgenie seek ${species}/fasta:genome)
+genome_fasta=$(refgenie seek ${species}--current/fasta:genome)
 gtf=$(refgenie seek $reference/ensembl_gtf:$referenceType )
 
 kallisto_version=$(grep "kallisto=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_smart-seq_quantification/envs/kallisto.yml | awk -F'=' '{print $2}' | tr -d '\n')
@@ -58,7 +58,7 @@ salmon_index=$(refgenie seek $reference/salmon_index:cdna_${referenceType}--salm
 
 mkdir -p $outDir
 ln -s $fasta $outDir/$(find_orig_refgenie_asset_name $fasta)
-mv $genome_fasta ${outDir}
+ln -s $genome_fasta $outDir/$(find_orig_refgenie_asset_name $genome_fasta)
 ln -s $gtf $outDir/$(find_orig_refgenie_asset_name $gtf)
 ln -s $(dirname $salmon_index) $outDir/salmon_index
 ln -s $(ls $(dirname $kallisto_index)/*.idx) $outDir/$(find_orig_refgenie_asset_name $fasta).idx

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -48,7 +48,7 @@ refinfo=$( refgenie list -g $reference )
 
 fasta=$(refgenie seek $reference/fasta_txome:cdna_$referenceType)
 genome_fasta=$(refgenie seek $reference/fasta:genome)
-gtf=$(refgenie seek $reference/ensembl_gtf:$referenceType )
+gtf=$(refgenie seek {$sepcies}--newest/ensembl_gtf:$referenceType )
 
 kallisto_version=$(grep "kallisto=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_smart-seq_quantification/envs/kallisto.yml | awk -F'=' '{print $2}' | tr -d '\n')
 kallisto_index=$(refgenie seek $reference/kallisto_index:cdna_${referenceType}--kallisto_v${kallisto_version})

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -54,7 +54,7 @@ kallisto_version=$(grep "kallisto=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflow
 kallisto_index=$(refgenie seek $reference/kallisto_index:cdna_${referenceType}--kallisto_v${kallisto_version})
 
 salmon_version=$(grep "salmon=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_droplet_quantification/envs/alevin.yml | awk -F'=' '{print $2}' | tr -d '\n')
-salmon_index=$(refgenie seek $reference/salmon_index:cdna_${referenceType}--salmon_v${salmon_version})
+salmon_index=$(refgenie seek $reference/salmon_index:splici_${referenceType}--salmon_v${salmon_version})
 
 mkdir -p $outDir
 ln -s $fasta $outDir/$(find_orig_refgenie_asset_name $fasta)

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -47,6 +47,7 @@ fi
 refinfo=$( refgenie list -g $reference )
 
 fasta=$(refgenie seek $reference/fasta_txome:cdna_$referenceType)
+genome_fasta=$(refgenie seek $reference/fasta:genome)
 gtf=$(refgenie seek $reference/ensembl_gtf:$referenceType )
 
 kallisto_version=$(grep "kallisto=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_smart-seq_quantification/envs/kallisto.yml | awk -F'=' '{print $2}' | tr -d '\n')
@@ -57,6 +58,7 @@ salmon_index=$(refgenie seek $reference/salmon_index:cdna_${referenceType}--salm
 
 mkdir -p $outDir
 ln -s $fasta $outDir/$(find_orig_refgenie_asset_name $fasta)
+ln -s $genome_fasta $outDir/$(find_orig_refgenie_asset_name $genome_fasta)
 ln -s $gtf $outDir/$(find_orig_refgenie_asset_name $gtf)
 ln -s $(dirname $salmon_index) $outDir/salmon_index
 ln -s $(ls $(dirname $kallisto_index)/*.idx) $outDir/$(find_orig_refgenie_asset_name $fasta).idx

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -58,7 +58,7 @@ salmon_index=$(refgenie seek $reference/salmon_index:cdna_${referenceType}--salm
 
 mkdir -p $outDir
 ln -s $fasta $outDir/$(find_orig_refgenie_asset_name $fasta)
-ln -s $genome_fasta ${outDir}/${genome_fasta})
-ln -s $gtf $outDir/$(find_orig_refgenie_asset_name $gtf
+ln -s $genome_fasta ${outDir}/${genome_fasta}
+ln -s $gtf $outDir/$(find_orig_refgenie_asset_name $gtf)
 ln -s $(dirname $salmon_index) $outDir/salmon_index
 ln -s $(ls $(dirname $kallisto_index)/*.idx) $outDir/$(find_orig_refgenie_asset_name $fasta).idx

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -58,7 +58,7 @@ salmon_index=$(refgenie seek $reference/salmon_index:cdna_${referenceType}--salm
 
 mkdir -p $outDir
 ln -s $fasta $outDir/$(find_orig_refgenie_asset_name $fasta)
-ln -s $genome_fasta ${outDir}/${genome_fasta}
+mv $genome_fasta ${outDir}
 ln -s $gtf $outDir/$(find_orig_refgenie_asset_name $gtf)
 ln -s $(dirname $salmon_index) $outDir/salmon_index
 ln -s $(ls $(dirname $kallisto_index)/*.idx) $outDir/$(find_orig_refgenie_asset_name $fasta).idx

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -47,7 +47,7 @@ fi
 refinfo=$( refgenie list -g $reference )
 
 fasta=$(refgenie seek $reference/fasta_txome:cdna_$referenceType)
-genome_fasta=$(refgenie seek ${species}--newest/fasta:genome)
+genome_fasta=$(refgenie seek ${species}/fasta:genome)
 gtf=$(refgenie seek $reference/ensembl_gtf:$referenceType )
 
 kallisto_version=$(grep "kallisto=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_smart-seq_quantification/envs/kallisto.yml | awk -F'=' '{print $2}' | tr -d '\n')

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -48,7 +48,7 @@ refinfo=$( refgenie list -g $reference )
 
 fasta=$(refgenie seek $reference/fasta_txome:cdna_$referenceType)
 genome_fasta=$(refgenie seek $reference/fasta:genome)
-gtf=$(refgenie seek {$sepcies}--newest/ensembl_gtf:$referenceType )
+gtf=$(refgenie seek ${species}--newest/ensembl_gtf:$referenceType )
 
 kallisto_version=$(grep "kallisto=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_smart-seq_quantification/envs/kallisto.yml | awk -F'=' '{print $2}' | tr -d '\n')
 kallisto_index=$(refgenie seek $reference/kallisto_index:cdna_${referenceType}--kallisto_v${kallisto_version})

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -47,7 +47,7 @@ fi
 refinfo=$( refgenie list -g $reference )
 
 fasta=$(refgenie seek $reference/fasta_txome:cdna_$referenceType)
-genome_fasta=$(refgenie seek ${species}--newest/fasta:genome)
+genome_fasta=$(refgenie seek $reference/fasta:genome)
 gtf=$(refgenie seek $reference/ensembl_gtf:$referenceType )
 
 kallisto_version=$(grep "kallisto=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_smart-seq_quantification/envs/kallisto.yml | awk -F'=' '{print $2}' | tr -d '\n')

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -48,7 +48,7 @@ refinfo=$( refgenie list -g $reference )
 
 fasta=$(refgenie seek $reference/fasta_txome:cdna_$referenceType)
 genome_fasta=$(refgenie seek $reference/fasta:genome)
-gtf=$(refgenie seek ${species}--newest/ensembl_gtf:$referenceType )
+gtf=$(refgenie seek ${species}/ensembl_gtf:$referenceType )
 
 kallisto_version=$(grep "kallisto=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_smart-seq_quantification/envs/kallisto.yml | awk -F'=' '{print $2}' | tr -d '\n')
 kallisto_index=$(refgenie seek $reference/kallisto_index:cdna_${referenceType}--kallisto_v${kallisto_version})

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -53,7 +53,7 @@ gtf=$(refgenie seek $reference/ensembl_gtf:$referenceType )
 kallisto_version=$(grep "kallisto=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_smart-seq_quantification/envs/kallisto.yml | awk -F'=' '{print $2}' | tr -d '\n')
 kallisto_index=$(refgenie seek $reference/kallisto_index:cdna_${referenceType}--kallisto_v${kallisto_version})
 
-salmon_version=$(grep "salmon=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_droplet_quantification/envs/alevin.yml | awk -F'=' '{print $2}' | tr -d '\n')
+salmon_version=$(grep "salmon=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_droplet_quantification/envs/alevin_fry.yml | awk -F'=' '{print $2}' | tr -d '\n')
 salmon_index=$(refgenie seek $reference/salmon_index:splici_${referenceType}--salmon_v${salmon_version})
 
 mkdir -p $outDir

--- a/bin/refgenieSeek.sh
+++ b/bin/refgenieSeek.sh
@@ -47,8 +47,8 @@ fi
 refinfo=$( refgenie list -g $reference )
 
 fasta=$(refgenie seek $reference/fasta_txome:cdna_$referenceType)
-genome_fasta=$(refgenie seek $reference/fasta:genome)
-gtf=$(refgenie seek ${species}/ensembl_gtf:$referenceType )
+genome_fasta=$(refgenie seek ${species}--newest/fasta:genome)
+gtf=$(refgenie seek $reference/ensembl_gtf:$referenceType )
 
 kallisto_version=$(grep "kallisto=" ${SCXA_WORKFLOW_ROOT}/workflow/scxa-workflows/w_smart-seq_quantification/envs/kallisto.yml | awk -F'=' '{print $2}' | tr -d '\n')
 kallisto_index=$(refgenie seek $reference/kallisto_index:cdna_${referenceType}--kallisto_v${kallisto_version})
@@ -58,7 +58,7 @@ salmon_index=$(refgenie seek $reference/salmon_index:cdna_${referenceType}--salm
 
 mkdir -p $outDir
 ln -s $fasta $outDir/$(find_orig_refgenie_asset_name $fasta)
-ln -s $genome_fasta $outDir/$(find_orig_refgenie_asset_name $genome_fasta)
+ln -s $genome_fasta ${outDir}/${genome_fasta})
 ln -s $gtf $outDir/$(find_orig_refgenie_asset_name $gtf)
 ln -s $(dirname $salmon_index) $outDir/salmon_index
 ln -s $(ls $(dirname $kallisto_index)/*.idx) $outDir/$(find_orig_refgenie_asset_name $fasta).idx

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -1079,10 +1079,10 @@ configs <- lapply(species_list, function(species){
           # For each library we check if there is a fastq URI that can supply the file
           uri_select <- apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files)         
                               
-          #missing_uri_files <- files[which(! apply(apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files), 1, any))]
-          #if (length(missing_uri_files) > 0){
-          #  stop(paste("Can't find URIs matching files:", paste(missing_uri_files, collapse=',')))
-          #}
+          missing_uri_files <- files[which(! apply(apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files), 1, any))]
+          if (length(missing_uri_files) > 0){
+            stop(paste("Can't find URIs matching files:", paste(missing_uri_files, collapse=',')))
+          }
                                                          
           nlibs <- nrow(species.protocol.sdrf)
           if (nlibs > 1){

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -961,6 +961,7 @@ configs <- lapply(species_list, function(species){
       paste0("    name = '", opt$name, "'"),
       paste0("    organism = '", species, "'"),
       paste0("    protocol = '", protocol, "'")
+      paste0("    experimentType = '", exp.type.name, "'")
     )
 
     config_fields <- c(run = run.col, layout = library.layout.col)

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -1079,10 +1079,10 @@ configs <- lapply(species_list, function(species){
           # For each library we check if there is a fastq URI that can supply the file
           uri_select <- apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files)         
                               
-          missing_uri_files <- files[which(! apply(apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files), 1, any))]
-          if (length(missing_uri_files) > 0){
-            stop(paste("Can't find URIs matching files:", paste(missing_uri_files, collapse=',')))
-          }
+          #missing_uri_files <- files[which(! apply(apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files), 1, any))]
+          #if (length(missing_uri_files) > 0){
+          #  stop(paste("Can't find URIs matching files:", paste(missing_uri_files, collapse=',')))
+          #}
                                                          
           nlibs <- nrow(species.protocol.sdrf)
           if (nlibs > 1){

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -960,7 +960,7 @@ configs <- lapply(species_list, function(species){
       "\nparams{",
       paste0("    name = '", opt$name, "'"),
       paste0("    organism = '", species, "'"),
-      paste0("    protocol = '", protocol, "'")
+      paste0("    protocol = '", protocol, "'"),
       paste0("    experimentType = '", exp.type.name, "'")
     )
 

--- a/bin/submitControlWorkflow.sh
+++ b/bin/submitControlWorkflow.sh
@@ -167,7 +167,7 @@ if [ $? -ne 0 ]; then
     rm -rf run.out run.err .nextflow.log*  
     bsub \
         -J "${controlJobName}" \
-        -M 8192 -R "rusage[mem=8192]" \
+        -M 16000 -R "rusage[mem=16000]" \
         -u $SCXA_REPORT_EMAIL \
         -o run.out \
         -e run.err \

--- a/envs/atlas-fastq-provider.yml
+++ b/envs/atlas-fastq-provider.yml
@@ -1,4 +1,4 @@
 name: atlas-fastq-provider
 dependencies:
-  - atlas-fastq-provider=0.2.6
+  - atlas-fastq-provider=0.4.6
   - pyyaml

--- a/envs/atlas-gene-annotation-manipulation.yml
+++ b/envs/atlas-gene-annotation-manipulation.yml
@@ -1,7 +1,7 @@
 name: atlas-gene-annotation-manipulation
 channels:
-  - conda-forge
   - bioconda
+  - conda-forge
   - ebi-gene-expression-group
 dependencies:
   - atlas-gene-annotation-manipulation=1.1.0

--- a/envs/atlas-gene-annotation-manipulation.yml
+++ b/envs/atlas-gene-annotation-manipulation.yml
@@ -2,7 +2,7 @@ name: atlas-gene-annotation-manipulation
 channels:
   - conda-forge
   - bioconda
-  - defaults
+  - ebi-gene-expression-group
 dependencies:
   - atlas-gene-annotation-manipulation=1.1.0
   - pyroe=0.6.2

--- a/envs/atlas-gene-annotation-manipulation.yml
+++ b/envs/atlas-gene-annotation-manipulation.yml
@@ -5,4 +5,4 @@ channels:
   - defaults
 dependencies:
   - atlas-gene-annotation-manipulation=1.1.0
-  - pyroe>=0.6.2
+  - pyroe=0.6.2

--- a/envs/atlas-gene-annotation-manipulation.yml
+++ b/envs/atlas-gene-annotation-manipulation.yml
@@ -2,7 +2,7 @@ name: atlas-gene-annotation-manipulation
 channels:
   - bioconda
   - conda-forge
-  - ebi-gene-expression-group
+  - defaults
 dependencies:
   - atlas-gene-annotation-manipulation=1.1.0
   - pyroe=0.6.2

--- a/envs/atlas-gene-annotation-manipulation.yml
+++ b/envs/atlas-gene-annotation-manipulation.yml
@@ -1,4 +1,8 @@
 name: atlas-gene-annotation-manipulation
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
 dependencies:
   - atlas-gene-annotation-manipulation=1.1.0
-  - pyroe=0.6.2
+  - pyroe>=0.6.2

--- a/envs/atlas-gene-annotation-manipulation.yml
+++ b/envs/atlas-gene-annotation-manipulation.yml
@@ -1,4 +1,4 @@
 name: atlas-gene-annotation-manipulation
 dependencies:
   - atlas-gene-annotation-manipulation=1.1.0
-  - pyroe
+  - pyroe=0.6.2

--- a/envs/atlas-gene-annotation-manipulation.yml
+++ b/envs/atlas-gene-annotation-manipulation.yml
@@ -1,3 +1,4 @@
 name: atlas-gene-annotation-manipulation
 dependencies:
   - atlas-gene-annotation-manipulation=1.1.0
+  - pyroe

--- a/main.nf
+++ b/main.nf
@@ -794,7 +794,7 @@ process transcript_to_gene {
         
     input:
         set val(espTag), val(expName), val(species), file(referenceFasta), file(referenceGtf), val(isDroplet) from REFS_FOR_T2GENE_DROPLET.join(IS_DROPLET_FOR_T2G)
-        set val(espTag), val(expName), val(species), file(referenceCDNA), file(Gtf) from REFS_FOR_T2GENE_NON_DROPLET
+        set val(espTag), val(expName), val(species), file(referenceCDNA) from REFS_FOR_T2GENE_NON_DROPLET.map{r -> tuple(r[0], r[1], r[2], r[4])}
        
 
     output:

--- a/main.nf
+++ b/main.nf
@@ -699,36 +699,43 @@ process check_privacy {
         set val(espTag), stdout into PRIVACY_STATUS
 
     """
-    apiKey="isPublic"
-    apiSearch="https://www.ebi.ac.uk/biostudies/api/v1/search?type=study&accession=${expName}"
-    response=\$(curl \$apiSearch)
+    if echo "\$expName" | grep -q "MTAB"; then
+        
+       apiKey="isPublic"
+       apiSearch="https://www.ebi.ac.uk/biostudies/api/v1/search?type=study&accession=${expName}"
+       response=\$(curl \$apiSearch)
 
-    if [ -z "\${response}" ]; then
-       #echo "ERROR: Got empty response from \${apiSearch} - unable to determine privacy status" >&2
-       exit 1
-    else
-        responseHit=\$(echo \${response} | jq .hits[0])
-        if [[ "\${responseHit}" == "null" ]]; then
-            #echo "WARNING: This search returned no hit: \${apiSearch}" >&2
-            expInfo=""
-        else
-            expInfo=\$(echo \$responseHit | jq ."\${apiKey}")
-            #if [[ "\${expInfo}" == "null" ]]; then
-            #    echo "WARNING: This key does not exist: \${apiKey}" >&2
-            #fi
-        fi
-    fi
+       if [ -z "\${response}" ]; then
+          #echo "ERROR: Got empty response from \${apiSearch} - unable to determine privacy status" >&2
+          exit 1
+       else
+           responseHit=\$(echo \${response} | jq .hits[0])
+           if [[ "\${responseHit}" == "null" ]]; then
+               #echo "WARNING: This search returned no hit: \${apiSearch}" >&2
+               expInfo=""
+           else
+               expInfo=\$(echo \$responseHit | jq ."\${apiKey}")
+               #if [[ "\${expInfo}" == "null" ]]; then
+               #    echo "WARNING: This key does not exist: \${apiKey}" >&2
+               #fi
+           fi
+       fi
 
-    if [[ -z "\$expInfo" ]]; then 
+       if [[ -z "\$expInfo" ]]; then 
         expInfo="false"; 
-    fi
+       fi
 
-    if [ "\$expInfo" == "true" ]; then
-        privacyStatus=public
+       if [ "\$expInfo" == "true" ]; then
+           privacyStatus=public
+       else
+           privacyStatus=private
+       fi
+       
     else
-        privacyStatus=private
+        # it's not MTAB
+        privacyStatus=public
     fi
-
+    
     echo -n "\$privacyStatus"
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -799,7 +799,7 @@ process transcript_to_gene {
 
     """
     if [ $isDroplet == 'True' ]; then
-        pyroe make-splici *.fa *.gtf.gz 100 splici_transcriptome
+        pyroe make-splici ${referenceFasta} ${referenceGtf} 100 splici_transcriptome
         mv splici_transcriptome/splici_fl*.tsv transcript_to_gene.txt
     else
         gtf2featureAnnotation.R --gtf-file $referenceGtf --version-transcripts \

--- a/main.nf
+++ b/main.nf
@@ -690,23 +690,41 @@ process reuse_tertiary {
 // Is experiment public or private?
 
 process check_privacy {
-
-    executor 'local'
-
+    conda "${baseDir}/envs/jq.yml"
     input:
         set val(espTag), val(expName), val(species), val(protocol) from TO_QUANTIFY_FOR_PRIVACY_CHECK.join(ESP_TAGS_FOR_PRIVACY_CHECK)
-
     output:
         set val(espTag), stdout into PRIVACY_STATUS
-
-    """
-    privacyStatus=\$(wget -O - http://peach.ebi.ac.uk:8480/api/privacy.txt?acc=${expName} 2>/dev/null | tr "\\t" "\\n" | awk -F':' '/privacy/ {print \$2}')
-    if [ -z "\$privacyStatus" ]; then
-      privacyStatus=public
-    fi    
-    echo -n "\$privacyStatus"
-    """
-}
+     """
+     apiKey="isPublic"
+     apiSearch="https://www.ebi.ac.uk/biostudies/api/v1/search?type=study&accession=${expName}"
+     response=\$(curl \$apiSearch)
+     if [ -z "\${response}" ]; then
+        #echo "ERROR: Got empty response from \${apiSearch} - unable to determine privacy status" >&2
+        exit 1
+     else
+         responseHit=\$(echo \${response} | jq .hits[0])
+         if [[ "\${responseHit}" == "null" ]]; then
+             #echo "WARNING: This search returned no hit: \${apiSearch}" >&2
+             expInfo=""
+         else
+             expInfo=\$(echo \$responseHit | jq ."\${apiKey}")
+             #if [[ "\${expInfo}" == "null" ]]; then
+             #    echo "WARNING: This key does not exist: \${apiKey}" >&2
+             #fi
+         fi
+     fi
+     if [[ -z "\$expInfo" ]]; then 
+         expInfo="false"; 
+     fi
+     if [ "\$expInfo" == "true" ]; then
+         privacyStatus=public
+     else
+         privacyStatus=private
+     fi
+     echo -n "\$privacyStatus"
+     """
+ }
 
 // Symlink to correct reference file, re-using the reference from last
 // quantification where appropriate. spikes are used in quantification only.

--- a/main.nf
+++ b/main.nf
@@ -740,7 +740,7 @@ process add_reference {
     else
         # Copy unspiked symlinks to spiked if no spikes are required
         mkdir spiked 
-        cp -P *.gtf.gz *.fa.gz salmon_index *.idx spiked
+        cp -P *.gtf.gz *.fa.gz *.fa salmon_index *.idx spiked
     fi
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -726,7 +726,7 @@ process add_reference {
 
     output:
         set val(espTag), file('spiked/*.fa.gz'), file("spiked/*.gtf.gz"), file('spiked/*.idx'), file('spiked/salmon_index') into PREPARED_REFERENCES
-        set val(espTag), val(expName), val(species), file('spiked/*.fa.gz'), file("spiked/*.gtf.gz") into REFS_FOR_T2GENE
+        set val(espTag), val(expName), val(species), file('spiked/*.fa'), file("spiked/*.gtf.gz") into REFS_FOR_T2GENE
         set val("${expName}-${species}"), file("*.fa.gz"), file("*.gtf.gz") into NEW_REFERENCES_FOR_DOWNSTREAM
 
     """
@@ -799,9 +799,7 @@ process transcript_to_gene {
 
     """
     if [ $isDroplet == 'True' ]; then
-        gunzip -f $referenceFasta
-        gunzip -f $referenceGtf
-        pyroe make-splici *.fa *.gtf 100 splici_transcriptome
+        pyroe make-splici *.fa *.gtf.gz 100 splici_transcriptome
         mv splici_transcriptome/splici_fl*.tsv transcript_to_gene.txt
     else
         gtf2featureAnnotation.R --gtf-file $referenceGtf --version-transcripts \

--- a/main.nf
+++ b/main.nf
@@ -397,7 +397,7 @@ IS_DROPLET.into{
     IS_DROPLET_PROT
     IS_DROPLET_FOR_EXP_SPECIES_TEST
     IS_DROPLET_FOR_REUSE_QUANT
-    IS_DROPLET_FOR_T2G
+    IS_DROPLET_FOR_TRANSCRIPT_TO_GENE
 }
 
 ESP_TAGS_FOR_IS_DROPLET
@@ -793,7 +793,7 @@ process transcript_to_gene {
     maxRetries 3
         
     input:
-        set val(espTag), val(expName), val(species), file(referenceFasta), file(referenceGtf), val(isDroplet) from REFS_FOR_T2GENE_DROPLET.join(IS_DROPLET_FOR_T2G)
+        set val(espTag), val(expName), val(species), file(referenceFasta), file(referenceGtf), val(isDroplet) from REFS_FOR_T2GENE_DROPLET.join(IS_DROPLET_FOR_TRANSCRIPT_TO_GENE)
         set val(espTag), val(expName), val(species), file(referenceCDNA) from REFS_FOR_T2GENE_NON_DROPLET
        
 

--- a/main.nf
+++ b/main.nf
@@ -799,8 +799,8 @@ process transcript_to_gene {
 
     """
     if [ $isDroplet == 'True' ]; then
-        gunzip $referenceFasta
-        gunzip $referenceGtf
+        gunzip -f $referenceFasta
+        gunzip -f $referenceGtf
         pyroe make-splici *.fa *.gtf 100 splici_transcriptome
         mv splici_transcriptome/splici_fl*.tsv transcript_to_gene.txt
     else

--- a/main.nf
+++ b/main.nf
@@ -799,7 +799,7 @@ process transcript_to_gene {
 
     """
     if [ $isDroplet == 'True' ]; then
-        pyroe make-splici ${referenceFasta} ${referenceGtf} 100 splici_transcriptome
+        pyroe make-splici ${referenceFasta} ${referenceGtf} 90 splici_transcriptome
         mv splici_transcriptome/splici_fl*.tsv transcript_to_gene.txt
     else
         gtf2featureAnnotation.R --gtf-file $referenceGtf --version-transcripts \

--- a/main.nf
+++ b/main.nf
@@ -194,7 +194,7 @@ process generate_configs {
 
     cache 'deep'
 
-    conda 'r-optparse r-data.table r-workflowscriptscommon pyyaml'
+    conda 'r-base r-optparse r-data.table r-workflowscriptscommon pyyaml'
 
     input:
         set val(esTag), val(expName), val(species), file(idfFile), file(sdrfFile), file(cellsFile) from  ES_TAGS_FOR_CONFIG.join(META_WITH_SPECIES_FOR_QUANT)

--- a/main.nf
+++ b/main.nf
@@ -725,9 +725,9 @@ process add_reference {
         set val(espTag), file(confFile), val(expName), val(species), val(protocol) from EXTENDED_CONF_FOR_REF.join(TO_QUANTIFY_FOR_REFERENCE).join(ESP_TAGS_FOR_REFERENCE)
 
     output:
-        set val(espTag), file('spiked/*.fa.gz'), file("spiked/*.gtf.gz"), file('spiked/*.idx'), file('spiked/salmon_index') into PREPARED_REFERENCES
+        set val(espTag), file('spiked/*.cdna.*.fa.gz'), file("spiked/*.gtf.gz"), file('spiked/*.idx'), file('spiked/salmon_index') into PREPARED_REFERENCES
         set val(espTag), val(expName), val(species), file('spiked/*toplevel.fa.gz'), file("spiked/*.gtf.gz") into REFS_FOR_T2GENE
-        set val("${expName}-${species}"), file(" *.cdna.*.fa.gz"), file("*.gtf.gz") into NEW_REFERENCES_FOR_DOWNSTREAM
+        set val("${expName}-${species}"), file("*.cdna.*.fa.gz"), file("*.gtf.gz") into NEW_REFERENCES_FOR_DOWNSTREAM
 
     """
     refgenieSeek.sh $species ${params.islReferenceType} "" \$(pwd)

--- a/main.nf
+++ b/main.nf
@@ -805,7 +805,7 @@ process transcript_to_gene {
         pyroe make-splici ${referenceFasta} ${referenceGtf} 90 splici_transcriptome
         mv splici_transcriptome/splici_fl*.tsv transcript_to_gene.txt
     else
-        gtf2featureAnnotation.R --gtf-file $Gtf --version-transcripts \
+        gtf2featureAnnotation.R --gtf-file $referenceGtf --version-transcripts \
         --parse-cdnas $referenceCDNA --parse-cdna-field "transcript_id" --feature-type \
         "transcript" --parse-cdna-names --fill-empty transcript_id --first-field \
         "transcript_id" --output-file transcript_to_gene.txt --fields "transcript_id,gene_id" \

--- a/main.nf
+++ b/main.nf
@@ -726,8 +726,8 @@ process add_reference {
 
     output:
         set val(espTag), file('spiked/*.fa.gz'), file("spiked/*.gtf.gz"), file('spiked/*.idx'), file('spiked/salmon_index') into PREPARED_REFERENCES
-        set val(espTag), val(expName), val(species), file('spiked/*.fa'), file("spiked/*.gtf.gz") into REFS_FOR_T2GENE
-        set val("${expName}-${species}"), file("*.fa.gz"), file("*.gtf.gz") into NEW_REFERENCES_FOR_DOWNSTREAM
+        set val(espTag), val(expName), val(species), file('spiked/*toplevel.fa'), file("spiked/*.gtf.gz") into REFS_FOR_T2GENE
+        set val("${expName}-${species}"), file(" *.cdna.*.fa.gz"), file("*.gtf.gz") into NEW_REFERENCES_FOR_DOWNSTREAM
 
     """
     refgenieSeek.sh $species ${params.islReferenceType} "" \$(pwd)
@@ -740,7 +740,7 @@ process add_reference {
     else
         # Copy unspiked symlinks to spiked if no spikes are required
         mkdir spiked 
-        cp -P *.gtf.gz *.fa.gz *.fa salmon_index *.idx spiked
+        cp -P *.gtf.gz *.fa.gz salmon_index *.idx spiked
     fi
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -799,7 +799,9 @@ process transcript_to_gene {
 
     """
     if [ $isDroplet == 'True' ]; then
-        pyroe make-splici $referenceFasta $referenceGtf 100 splici_transcriptome
+        gunzip $referenceFasta
+        gunzip $referenceGtf
+        pyroe make-splici *.fa *.gtf 100 splici_transcriptome
         mv splici_transcriptome/splici_fl*.tsv transcript_to_gene.txt
     else
         gtf2featureAnnotation.R --gtf-file $referenceGtf --version-transcripts \

--- a/main.nf
+++ b/main.nf
@@ -794,7 +794,7 @@ process transcript_to_gene {
         
     input:
         set val(espTag), val(expName), val(species), file(referenceFasta), file(referenceGtf), val(isDroplet) from REFS_FOR_T2GENE_DROPLET.join(IS_DROPLET_FOR_T2G)
-        set val(espTag), val(expName), val(species), file(referenceCDNA), file(referenceGtf) from REFS_FOR_T2GENE_NON_DROPLET
+        set val(espTag), val(expName), val(species), file(referenceCDNA), file(Gtf) from REFS_FOR_T2GENE_NON_DROPLET
        
 
     output:
@@ -805,7 +805,7 @@ process transcript_to_gene {
         pyroe make-splici ${referenceFasta} ${referenceGtf} 90 splici_transcriptome
         mv splici_transcriptome/splici_fl*.tsv transcript_to_gene.txt
     else
-        gtf2featureAnnotation.R --gtf-file $referenceGtf --version-transcripts \
+        gtf2featureAnnotation.R --gtf-file $Gtf --version-transcripts \
         --parse-cdnas $referenceCDNA --parse-cdna-field "transcript_id" --feature-type \
         "transcript" --parse-cdna-names --fill-empty transcript_id --first-field \
         "transcript_id" --output-file transcript_to_gene.txt --fields "transcript_id,gene_id" \

--- a/main.nf
+++ b/main.nf
@@ -726,7 +726,7 @@ process add_reference {
 
     output:
         set val(espTag), file('spiked/*.fa.gz'), file("spiked/*.gtf.gz"), file('spiked/*.idx'), file('spiked/salmon_index') into PREPARED_REFERENCES
-        set val(espTag), val(expName), val(species), file('spiked/*toplevel.fa'), file("spiked/*.gtf.gz") into REFS_FOR_T2GENE
+        set val(espTag), val(expName), val(species), file('spiked/*toplevel.fa.gz'), file("spiked/*.gtf.gz") into REFS_FOR_T2GENE
         set val("${expName}-${species}"), file(" *.cdna.*.fa.gz"), file("*.gtf.gz") into NEW_REFERENCES_FOR_DOWNSTREAM
 
     """

--- a/main.nf
+++ b/main.nf
@@ -727,7 +727,7 @@ process add_reference {
     output:
         set val(espTag), file('spiked/*.cdna.*.fa.gz'), file("spiked/*.gtf.gz"), file('spiked/*.idx'), file('spiked/salmon_index') into PREPARED_REFERENCES
         set val(espTag), val(expName), val(species), file('spiked/*toplevel.fa.gz'), file("spiked/*.gtf.gz") into REFS_FOR_T2GENE_DROPLET
-        set val(espTag), val(expName), val(species), file("*.cdna.*.fa.gz"), file("spiked/*.gtf.gz") into REFS_FOR_T2GENE_NON_DROPLET
+        set val(espTag), val(expName), val(species), file("*.cdna.*.fa.gz") into REFS_FOR_T2GENE_NON_DROPLET
         set val("${expName}-${species}"), file("*.cdna.*.fa.gz"), file("*.gtf.gz") into NEW_REFERENCES_FOR_DOWNSTREAM
 
     """
@@ -794,7 +794,7 @@ process transcript_to_gene {
         
     input:
         set val(espTag), val(expName), val(species), file(referenceFasta), file(referenceGtf), val(isDroplet) from REFS_FOR_T2GENE_DROPLET.join(IS_DROPLET_FOR_T2G)
-        set val(espTag), val(expName), val(species), file(referenceCDNA) from REFS_FOR_T2GENE_NON_DROPLET.map{r -> tuple(r[0], r[1], r[2], r[4])}
+        set val(espTag), val(expName), val(species), file(referenceCDNA) from REFS_FOR_T2GENE_NON_DROPLET
        
 
     output:

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,7 +16,7 @@ executor {
 
 conda {
     cacheDir = "$SCXA_WORKFLOW_ROOT/envs"
-    createTimeout = "30 min"
+    createTimeout = "1 h"
 }
 
 env {

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,7 +16,8 @@ executor {
 
 conda {
     cacheDir = "$SCXA_WORKFLOW_ROOT/envs"
-    createTimeout = "3 h"
+    createTimeout = "1 h"
+    useMamba=true
 }
 
 env {

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,7 @@ conda {
     cacheDir = "$SCXA_WORKFLOW_ROOT/envs"
     createTimeout = "2 h"
     useMamba=false
+    createOptions = "--no-channel-priority"
 }
 
 env {

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,8 +16,8 @@ executor {
 
 conda {
     cacheDir = "$SCXA_WORKFLOW_ROOT/envs"
-    createTimeout = "1 h"
-    useMamba=true
+    createTimeout = "2 h"
+    useMamba=false
 }
 
 env {

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,7 +16,7 @@ executor {
 
 conda {
     cacheDir = "$SCXA_WORKFLOW_ROOT/envs"
-    createTimeout = "1 h"
+    createTimeout = "3 h"
 }
 
 env {


### PR DESCRIPTION
Two changes are necessary to the scxa-control-workflow if we switch from alevin to alevin-fry in the scxa droplet quantification workflow: 

- Make a specific transcript_to_gene.txt that is required for alevin-fry

Currently a two-column  transcript_to_gene.txt is produced, but alevin-fry required a three-column one three the third column is the splice status of the transcript.
This transcript_to_gene file is made by running `pyroe make_splici`.


- Add AEExperimentType to config file for droplet quantification workflow

The AEExperimentType field in the idf file specifies the type of experiment. 
We pass that information to the experiment configuration file that is used in the droplet quantification workflow (https://github.com/ebi-gene-expression-group/scxa-droplet-quantification-workflow/blob/e6db214a9a75472192521832c7083153851d00d9/main.nf#L9).

We need to do this because alevin-fry quantifies spliced and unspliced transcripts for single cell and single nucleus. 

But when we read in the matrix we need to speficify wether it's **snRNA** (intronic regions are quantified) or **scRNA**  (intronic regions are not quantified). See https://github.com/COMBINE-lab/pyroe/blob/main/README.md#load_fry-notes for more information.

So basically the config file changes from this:

```
params{
    name = 'E-MTAB-7094'
    organism = 'mus_musculus'
    protocol = '10xv2'

....
```

to this:

```

params{
    name = 'E-MTAB-7094'
    organism = 'mus_musculus'
    protocol = '10xv2'
    experimentType = 'single_cell'

....
```


