### PR TITLE
Fixing nexflow bug in switching Privacy status query from Peach to BioStudies API

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -701,35 +701,35 @@ process check_privacy {
     """
     apiKey="isPublic"
     apiSearch="https://www.ebi.ac.uk/biostudies/api/v1/search?type=study&accession=${expName}"
-    response=$(curl $apiSearch)
+    response=\$(curl \$apiSearch)
 
-    if [ -z "${response}" ]; then
-       #echo "ERROR: Got empty response from ${apiSearch} - unable to determine privacy status" >&2
+    if [ -z "\${response}" ]; then
+       #echo "ERROR: Got empty response from \${apiSearch} - unable to determine privacy status" >&2
        exit 1
     else
-        responseHit=$(echo ${response} | jq .hits[0])
-        if [[ "${responseHit}" == "null" ]]; then
-            #echo "WARNING: This search returned no hit: ${apiSearch}" >&2
+        responseHit=\$(echo \${response} | jq .hits[0])
+        if [[ "\${responseHit}" == "null" ]]; then
+            #echo "WARNING: This search returned no hit: \${apiSearch}" >&2
             expInfo=""
         else
-            expInfo=$(echo $responseHit | jq ."${apiKey}")
-            #if [[ "${expInfo}" == "null" ]]; then
-            #    echo "WARNING: This key does not exist: ${apiKey}" >&2
+            expInfo=\$(echo \$responseHit | jq ."\${apiKey}")
+            #if [[ "\${expInfo}" == "null" ]]; then
+            #    echo "WARNING: This key does not exist: \${apiKey}" >&2
             #fi
         fi
     fi
 
-    if [[ -z "$expInfo" ]]; then 
+    if [[ -z "\$expInfo" ]]; then 
         expInfo="false"; 
     fi
 
-    if [ "$expInfo" == "true" ]; then
+    if [ "\$expInfo" == "true" ]; then
         privacyStatus=public
     else
         privacyStatus=private
     fi
 
-    echo -n "$privacyStatus"
+    echo -n "\$privacyStatus"
     """
 }
 


### PR DESCRIPTION
Added escape character `\` so nextflow pipeline won't fail