### PR TITLE
modify spiked cDNA outputfile name - second try

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -757,7 +757,7 @@ process add_reference {
         set val(espTag), file(confFile), val(expName), val(species), val(protocol) from EXTENDED_CONF_FOR_REF.join(TO_QUANTIFY_FOR_REFERENCE).join(ESP_TAGS_FOR_REFERENCE)
 
     output:
-        set val(espTag), file('spiked/*cdna.fa.gz'), file("spiked/*.gtf.gz"), file('spiked/*.idx'), file('spiked/salmon_index') into PREPARED_REFERENCES
+        set val(espTag), file('spiked/*cdna*.fa.gz'), file("spiked/*.gtf.gz"), file('spiked/*.idx'), file('spiked/salmon_index') into PREPARED_REFERENCES
         set val(espTag), val(expName), val(species), file('spiked/*toplevel.fa.gz'), file("spiked/*.gtf.gz") into REFS_FOR_T2GENE_DROPLET
         set val(espTag), val(expName), val(species), file("*.cdna.*.fa.gz") into REFS_FOR_T2GENE_NON_DROPLET
         set val("${expName}-${species}"), file("*.cdna.*.fa.gz"), file("*.gtf.gz") into NEW_REFERENCES_FOR_DOWNSTREAM


### PR DESCRIPTION
Previous PR:
During the changes necessary for alevin-fry, the output file spiked/\*.fa.gz was accidentaly changed to spiked/\*.cdna.*.fa.gz.
This leads to an error as the spiked cDNA files, which are named like this drosophila_melanogaster-BDGP6_32-metazoa53-ercc.cdna.fa.gz can not be found.
This PR fixes this.
Correction:
To match the spiked  cDNA reference we need `spiked/\*.cdna*.fa.gz` as an output file to match also files like this
`Homo_sapiens.GRCh38.cdna.all.107.fa.gz`