### PR TITLE
Fix error in sdrfToNfConf.R

### DIFF
--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -1079,8 +1079,14 @@ configs <- lapply(species_list, function(species){
           # For each library we check if there is a fastq URI that can supply the file
           uri_select <- apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files)         
           
-          # the following line gives an error: dim(X) must have a positive length
-          missing_uri_files <- files[which(! apply(apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files), 1, any))]
+          if (is.data.frame(uri_select) || is.matrix(uri_select)) {
+            # the following line gives an error: dim(X) must have a positive length
+            # if not a matrix or a data.frame
+            missing_uri_files <- files[which(! apply(apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files), 1, any))]
+          } else {
+            missing_uri_files <- files[which(! apply(as.data.frame( apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files) ), 1, any))]
+          }
+            
           if (length(missing_uri_files) > 0){
             stop(paste("Can't find URIs matching files:", paste(missing_uri_files, collapse=',')))
           }

--- a/bin/sdrfToNfConf.R
+++ b/bin/sdrfToNfConf.R
@@ -1078,7 +1078,8 @@ configs <- lapply(species_list, function(species){
 
           # For each library we check if there is a fastq URI that can supply the file
           uri_select <- apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files)         
-                              
+          
+          # the following line gives an error: dim(X) must have a positive length
           missing_uri_files <- files[which(! apply(apply(species.protocol.sdrf[,uri_cols], 2, function(x) basename(x) == files), 1, any))]
           if (length(missing_uri_files) > 0){
             stop(paste("Can't find URIs matching files:", paste(missing_uri_files, collapse=',')))


### PR DESCRIPTION
The following error was found for a couple of studies

```
Command error:
  Error in apply(apply(species.protocol.sdrf[, uri_cols], 2, function(x) basename(x) ==  : 
    dim(X) must have a positive length
  Calls: lapply -> FUN -> lapply -> FUN -> which -> apply
  Execution halted
```

This error occurs when you attempt to use the apply() function to calculate some metric for a column of a data frame or matrix, yet provide a vector as an argument instead of a data frame or matrix.

This happens for some accessions such as E-MTAB-8848 that have only one URI fastq row in the SDRF.