### PR TITLE
Adapt hackathon changes into the control workflow

### DIFF
--- a/conf/protocol/droplet.conf
+++ b/conf/protocol/droplet.conf
@@ -61,7 +61,7 @@ params {
         find_clusters {
             flavor = 'vtraag'
             restrict_to = 'none'
-            key_added = 'louvain'
+            key_added = 'leiden'
             use_weights = 'false' 
             random_seed = 1234 
             resolutions = [ '0.1', '0.3', '0.5', '0.7', '1.0', '2.0', '3.0', '4.0', '5.0' ]
@@ -98,7 +98,7 @@ params {
             projection = '2d'
         }
         find_markers{
-            groupby = 'louvain'
+            groupby = 'leiden'
             groups = 'none'
             reference = 'rest'
             n_genes = 100

--- a/conf/protocol/smart.conf
+++ b/conf/protocol/smart.conf
@@ -103,7 +103,7 @@ params {
         find_clusters {
             flavor = 'vtraag'
             restrict_to = 'none'
-            key_added = 'louvain'
+            key_added = 'leiden'
             use_weights = 'false' 
             random_seed = 1234 
             resolutions = [ '0.1', '0.3', '0.5', '0.7', '1.0', '2.0', '3.0', '4.0', '5.0' ]
@@ -140,7 +140,7 @@ params {
             projection = '2d'
         }
         find_markers{
-            groupby = 'louvain'
+            groupby = 'leiden'
             groups = 'none'
             reference = 'rest'
             n_genes = 100


### PR DESCRIPTION
Changes made here allow for changes made in the scxa-tertiary-workflow during the nf-core hackathon to be adapted by the control workflow. Below are the changes made during the hackathon that are addressed in this PR:

- [x] Change in the clustering algorithm used (Louvain --> Leiden) (https://github.com/ebi-gene-expression-group/scxa-tertiary-workflow/pull/51)